### PR TITLE
feat: enforce per-tool scopes for scoped agent credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ ZENROWS_API_KEY=your_api_key_here
 
 # Optional: enable browser tools
 # ZENROWS_BROWSER_URL=http://localhost:12345
+
+# Optional: credential introspection endpoint used to enforce per-tool scopes for
+# scoped agent credentials. Legacy user API keys are unaffected (no scope data).
+# ZENROWS_INTROSPECTION_URL=https://api.zenrows.com/me/credential

--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ The AI selects the right tool from your prompt. You don't call tools directly in
 
 See the [full tool reference](https://docs.zenrows.com/integrations/mcp/mcp-overview#tools) for every tool, parameter, and return value.
 
+### Credentials & scopes
+
+Authenticate with either a ZenRows API key or a **scoped agent credential** (obtained via OAuth — e.g. `npx zenrows login`, or the MCP OAuth flow this server advertises at `/.well-known/oauth-*`). Present it as `Authorization: Bearer <credential>` or `?apikey=<credential>`.
+
+- **API keys** have full account access (unchanged behavior).
+- **Agent credentials** are scoped: the server introspects them and enforces per-tool scopes. `scrape` needs `scrape:write` (plus `extract:json` for structured extraction); `browser_*` needs `browser:session_write` (a production scope that requires approval). A call missing a scope returns an `insufficient_scope` error pointing to **Settings → Agents**. Configurable via `ZENROWS_INTROSPECTION_URL`.
+
 ---
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "inspect": "npm run build && npx @modelcontextprotocol/inspector node dist/index.js",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
+    "test": "node --import tsx --test tests/*.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run clean && npm run build && npm run typecheck && npm run lint",
     "publish-beta": "npm publish --tag beta",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,91 @@
+/**
+ * Per-tool scope enforcement for scoped ZenRows agent credentials.
+ *
+ * The ZenRows app issues scoped, revocable agent credentials and exposes an
+ * introspection endpoint (`GET /me/credential`). This module asks that endpoint
+ * what a presented credential is allowed to do and gates tool calls accordingly.
+ *
+ * Backwards compatible by design:
+ *   - 200 from introspection  → a scoped agent credential; enforce its scopes.
+ *   - 401 (legacy user API key, or revoked/invalid) → no scope data; pass through
+ *     unchanged. A truly invalid key is still rejected by the Scraper API on use.
+ *   - introspection outage    → fail open to pass-through (availability over a
+ *     check the Scraper API ultimately backstops).
+ */
+
+const INTROSPECTION_URL =
+  process.env.ZENROWS_INTROSPECTION_URL ?? "https://api.zenrows.com/me/credential";
+
+const CACHE_TTL_MS = 60_000;
+
+interface Introspection {
+  /** True only when the credential is a scoped agent credential. */
+  scoped: boolean;
+  scopes: Set<string>;
+}
+
+const cache = new Map<string, { at: number; value: Introspection }>();
+
+/** Resolve (and briefly cache) what a credential is allowed to do. */
+export async function introspect(apiKey: string): Promise<Introspection> {
+  const hit = cache.get(apiKey);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.value;
+
+  let value: Introspection = { scoped: false, scopes: new Set() };
+  try {
+    const res = await fetch(INTROSPECTION_URL, {
+      headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (res.ok) {
+      const body = (await res.json()) as { data?: { scopes?: string[] } };
+      value = { scoped: true, scopes: new Set(body.data?.scopes ?? []) };
+    }
+    // Any non-200 (incl. 401 for legacy keys) → pass-through (scoped: false).
+  } catch {
+    // Introspection unreachable → fail open to pass-through.
+  }
+
+  cache.set(apiKey, { at: Date.now(), value });
+  return value;
+}
+
+/**
+ * Returns a human/agent-readable denial message when a scoped credential lacks
+ * the required scopes, or `null` when the call is allowed (including all legacy
+ * keys, which carry no scope restrictions).
+ */
+export async function guardScopes(apiKey: string, required: string[]): Promise<string | null> {
+  const { scoped, scopes } = await introspect(apiKey);
+  if (!scoped) return null;
+
+  const missing = required.filter((s) => !scopes.has(s));
+  if (missing.length === 0) return null;
+
+  return (
+    `insufficient_scope: this agent credential is missing ${missing.join(", ")}. ` +
+    `Grant it in Settings → Agents (some scopes require admin approval), ` +
+    `or connect a credential that already has it.`
+  );
+}
+
+/** Scopes required by the browser automation tools (a production capability). */
+export const BROWSER_SCOPES = ["scrape:write", "browser:session_write"];
+
+/** Scopes required by the `scrape` tool, given its parameters. */
+export function scrapeScopes(params: {
+  autoparse?: boolean;
+  css_extractor?: string;
+  outputs?: string;
+}): string[] {
+  const scopes = ["scrape:write"];
+  if (params.autoparse || params.css_extractor || params.outputs) {
+    scopes.push("extract:json");
+  }
+  return scopes;
+}
+
+/** Test seam: clear the introspection cache. */
+export function clearIntrospectionCache(): void {
+  cache.clear();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { createRequire } from "module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { guardScopes, scrapeScopes } from "./auth.js";
 import { registerBrowserTools } from "./tools/browser.js";
 
 const require = createRequire(import.meta.url);
@@ -11,7 +12,8 @@ const ZENROWS_API_URL = "https://api.zenrows.com/v1/";
 const DEFAULT_JS_RENDER = process.env.ZENROWS_JS_RENDER === "true";
 const DEFAULT_PREMIUM_PROXY = process.env.ZENROWS_PREMIUM_PROXY === "true";
 const DEFAULT_RESPONSE_TYPE =
-  (process.env.ZENROWS_RESPONSE_TYPE as "markdown" | "plaintext" | "html" | undefined) ?? "markdown";
+  (process.env.ZENROWS_RESPONSE_TYPE as "markdown" | "plaintext" | "html" | undefined) ??
+  "markdown";
 
 export function createServer(apiKey: string, clientName?: string): McpServer {
   const server = new McpServer({
@@ -171,6 +173,11 @@ Examples:
       },
     },
     async (params) => {
+      const denial = await guardScopes(apiKey, scrapeScopes(params));
+      if (denial) {
+        return { content: [{ type: "text" as const, text: denial }], isError: true as const };
+      }
+
       const searchParams = new URLSearchParams({
         apikey: apiKey,
         url: params.url,

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { browserFetch, browserError } from "./browser-fetch.js";
+import { BROWSER_SCOPES, guardScopes } from "../auth.js";
+import { browserFetch, browserError, type BrowserFetchResult } from "./browser-fetch.js";
 
 type TextContent = { type: "text"; text: string };
 type ImageContent = { type: "image"; data: string; mimeType: "image/png" | "image/jpeg" };
@@ -19,16 +20,34 @@ function json(data: unknown): { content: TextContent[] } {
 
 const sessionId = z.string().describe("Session ID returned by browser_navigate");
 
-export function registerBrowserTools(server: McpServer, apiKey: string, browserUrl: string, getClientName: () => string | undefined): void {
-  const tfetch = (toolName: string) => (method: string, path: string, body?: unknown) =>
-    browserFetch(method, path, apiKey, browserUrl, body, getClientName(), toolName);
+export function registerBrowserTools(
+  server: McpServer,
+  apiKey: string,
+  browserUrl: string,
+  getClientName: () => string | undefined
+): void {
+  const tfetch =
+    (toolName: string) =>
+    async (method: string, path: string, body?: unknown): Promise<BrowserFetchResult> => {
+      // Browser automation is a production capability; enforce its scopes on every
+      // call. Legacy keys (no scope data) pass through unchanged.
+      const denial = await guardScopes(apiKey, BROWSER_SCOPES);
+      if (denial) {
+        return { ok: false, status: 403, data: { error: denial } };
+      }
+      return browserFetch(method, path, apiKey, browserUrl, body, getClientName(), toolName);
+    };
 
   // ─── Session ─────────────────────────────────────────────────────────────
 
   server.registerTool(
     "browser_navigate",
     {
-      annotations: { title: "Open Browser & Navigate", readOnlyHint: false, destructiveHint: false },
+      annotations: {
+        title: "Open Browser & Navigate",
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
       description: `Open a ZenRows Scraping Browser session and navigate to a URL.
 
 This is the entry point for all browser automation. It creates a new session backed by
@@ -45,8 +64,15 @@ When to use options:
         proxy_country: z
           .string()
           .optional()
-          .describe("ISO 3166-1 alpha-2 country code for geo-targeted proxy (e.g. 'US', 'GB', 'DE')"),
-        proxy_region: z.string().optional().describe("World region code for geo-targeted proxy (eu=Europe, na=North America, ap=Asia Pacific, sa=South America, af=Africa, me=Middle East)"),
+          .describe(
+            "ISO 3166-1 alpha-2 country code for geo-targeted proxy (e.g. 'US', 'GB', 'DE')"
+          ),
+        proxy_region: z
+          .string()
+          .optional()
+          .describe(
+            "World region code for geo-targeted proxy (eu=Europe, na=North America, ap=Asia Pacific, sa=South America, af=Africa, me=Middle East)"
+          ),
       },
     },
     async (params) => {
@@ -65,7 +91,9 @@ When to use options:
 
       let navResult;
       try {
-        navResult = await fetch("POST", `/browser/sessions/${session.session_id}/navigate`, { url: params.url });
+        navResult = await fetch("POST", `/browser/sessions/${session.session_id}/navigate`, {
+          url: params.url,
+        });
       } catch (e) {
         // Best-effort cleanup — session was created but navigation failed, free the slot.
         void fetch("DELETE", `/browser/sessions/${session.session_id}`).catch(() => undefined);
@@ -77,7 +105,12 @@ When to use options:
       }
       const nav = navResult.data as { url: string; title: string };
 
-      return json({ session_id: session.session_id, url: nav.url, title: nav.title, expires_at: session.expires_at });
+      return json({
+        session_id: session.session_id,
+        url: nav.url,
+        title: nav.title,
+        expires_at: session.expires_at,
+      });
     }
   );
 
@@ -85,7 +118,8 @@ When to use options:
     "browser_close",
     {
       annotations: { title: "Close Browser Session", readOnlyHint: false, destructiveHint: false },
-      description: "Close a browser session and free all associated resources. Always call this when done to release the browser slot.",
+      description:
+        "Close a browser session and free all associated resources. Always call this when done to release the browser slot.",
       inputSchema: { session_id: sessionId },
     },
     async ({ session_id }) => {
@@ -165,7 +199,8 @@ When to use options:
     "browser_click",
     {
       annotations: { title: "Click Element", readOnlyHint: false, destructiveHint: false },
-      description: "Click an element on the page using a CSS selector. Use browser_get_accessibility_tree first to find the right selector.",
+      description:
+        "Click an element on the page using a CSS selector. Use browser_get_accessibility_tree first to find the right selector.",
       inputSchema: {
         session_id: sessionId,
         selector: z.string().describe("CSS selector of the element to click"),
@@ -209,18 +244,26 @@ When to use options:
     "browser_type",
     {
       annotations: { title: "Type Text", readOnlyHint: false, destructiveHint: false },
-      description: "Type text into an input element. Appends to existing content unless clear_first is set.",
+      description:
+        "Type text into an input element. Appends to existing content unless clear_first is set.",
       inputSchema: {
         session_id: sessionId,
         selector: z.string().describe("CSS selector of the input element"),
         text: z.string().describe("Text to type"),
-        clear_first: z.boolean().optional().describe("Clear existing content before typing (default false)"),
+        clear_first: z
+          .boolean()
+          .optional()
+          .describe("Clear existing content before typing (default false)"),
       },
     },
     async ({ session_id, selector, text, clear_first }) => {
       const fetch = tfetch("browser_type");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/type`, { selector, text, clear_first });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/type`, {
+          selector,
+          text,
+          clear_first,
+        });
         if (!result.ok) return err(`Type failed: ${browserError(result)}`);
         return ok();
       } catch (e) {
@@ -233,7 +276,8 @@ When to use options:
     "browser_fill",
     {
       annotations: { title: "Fill Input", readOnlyHint: false, destructiveHint: false },
-      description: "Clear an input field and set its value. Preferred over browser_type when replacing the full value.",
+      description:
+        "Clear an input field and set its value. Preferred over browser_type when replacing the full value.",
       inputSchema: {
         session_id: sessionId,
         selector: z.string().describe("CSS selector of the input element"),
@@ -243,7 +287,10 @@ When to use options:
     async ({ session_id, selector, value }) => {
       const fetch = tfetch("browser_fill");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/fill`, { selector, value });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/fill`, {
+          selector,
+          value,
+        });
         if (!result.ok) return err(`Fill failed: ${browserError(result)}`);
         return ok();
       } catch (e) {
@@ -266,7 +313,10 @@ When to use options:
     async ({ session_id, selector, value }) => {
       const fetch = tfetch("browser_select_option");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/select`, { selector, value });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/select`, {
+          selector,
+          value,
+        });
         if (!result.ok) return err(`Select failed: ${browserError(result)}`);
         return ok();
       } catch (e) {
@@ -345,10 +395,13 @@ When to use options:
     "browser_press_key",
     {
       annotations: { title: "Press Key", readOnlyHint: false, destructiveHint: false },
-      description: 'Press a keyboard key. Examples: "Enter", "Tab", "Escape", "ArrowDown", "Control+a".',
+      description:
+        'Press a keyboard key. Examples: "Enter", "Tab", "Escape", "ArrowDown", "Control+a".',
       inputSchema: {
         session_id: sessionId,
-        key: z.string().describe('Key to press (e.g. "Enter", "Tab", "Escape", "ArrowDown", "Control+a")'),
+        key: z
+          .string()
+          .describe('Key to press (e.g. "Enter", "Tab", "Escape", "ArrowDown", "Control+a")'),
       },
     },
     async ({ session_id, key }) => {
@@ -377,7 +430,10 @@ When to use options:
     async ({ session_id, direction, distance }) => {
       const fetch = tfetch("browser_scroll");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/scroll`, { direction, distance });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/scroll`, {
+          direction,
+          distance,
+        });
         if (!result.ok) return err(`Scroll failed: ${browserError(result)}`);
         return ok();
       } catch (e) {
@@ -486,13 +542,18 @@ labels, and states — everything needed to drive browser interactions.`,
       description: "Get the visible text content of an element or the entire page body.",
       inputSchema: {
         session_id: sessionId,
-        selector: z.string().optional().describe("CSS selector of the element (omit for full page body text)"),
+        selector: z
+          .string()
+          .optional()
+          .describe("CSS selector of the element (omit for full page body text)"),
       },
     },
     async ({ session_id, selector }) => {
       const fetch = tfetch("browser_get_text");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/get_text`, { selector });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/get_text`, {
+          selector,
+        });
         if (!result.ok) return err(`Failed to get text: ${browserError(result)}`);
         const data = result.data as { text: string };
         return { content: [{ type: "text" as const, text: data.text }] };
@@ -510,13 +571,18 @@ labels, and states — everything needed to drive browser interactions.`,
       inputSchema: {
         session_id: sessionId,
         selector: z.string().describe("CSS selector of the element"),
-        attribute: z.string().describe("Attribute name to retrieve (e.g. 'href', 'src', 'data-id')"),
+        attribute: z
+          .string()
+          .describe("Attribute name to retrieve (e.g. 'href', 'src', 'data-id')"),
       },
     },
     async ({ session_id, selector, attribute }) => {
       const fetch = tfetch("browser_get_attribute");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/get_attribute`, { selector, attribute });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/get_attribute`, {
+          selector,
+          attribute,
+        });
         if (!result.ok) return err(`Failed to get attribute: ${browserError(result)}`);
         return json(result.data);
       } catch (e) {
@@ -532,13 +598,18 @@ labels, and states — everything needed to drive browser interactions.`,
       description: "Get the HTML source of an element or the full page.",
       inputSchema: {
         session_id: sessionId,
-        selector: z.string().optional().describe("CSS selector of the element (omit for full page HTML)"),
+        selector: z
+          .string()
+          .optional()
+          .describe("CSS selector of the element (omit for full page HTML)"),
       },
     },
     async ({ session_id, selector }) => {
       const fetch = tfetch("browser_get_html");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/get_html`, { selector });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/get_html`, {
+          selector,
+        });
         if (!result.ok) return err(`Failed to get HTML: ${browserError(result)}`);
         const data = result.data as { html: string };
         return { content: [{ type: "text" as const, text: data.html }] };
@@ -551,8 +622,13 @@ labels, and states — everything needed to drive browser interactions.`,
   server.registerTool(
     "browser_query_selector_all",
     {
-      annotations: { title: "Query All Matching Elements", readOnlyHint: true, destructiveHint: false },
-      description: "Find all elements matching a CSS selector and return their text, HTML, and attributes.",
+      annotations: {
+        title: "Query All Matching Elements",
+        readOnlyHint: true,
+        destructiveHint: false,
+      },
+      description:
+        "Find all elements matching a CSS selector and return their text, HTML, and attributes.",
       inputSchema: {
         session_id: sessionId,
         selector: z.string().describe("CSS selector to query"),
@@ -561,7 +637,9 @@ labels, and states — everything needed to drive browser interactions.`,
     async ({ session_id, selector }) => {
       const fetch = tfetch("browser_query_selector_all");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/query_selector_all`, { selector });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/query_selector_all`, {
+          selector,
+        });
         if (!result.ok) return err(`Query failed: ${browserError(result)}`);
         return json(result.data);
       } catch (e) {
@@ -576,10 +654,14 @@ labels, and states — everything needed to drive browser interactions.`,
     "browser_screenshot",
     {
       annotations: { title: "Take Screenshot", readOnlyHint: true, destructiveHint: false },
-      description: "Take a screenshot of the current page or a specific element. Use for visual verification or when the accessibility tree is not sufficient.",
+      description:
+        "Take a screenshot of the current page or a specific element. Use for visual verification or when the accessibility tree is not sufficient.",
       inputSchema: {
         session_id: sessionId,
-        full_page: z.boolean().optional().describe("Capture full page including content below the fold (default false)"),
+        full_page: z
+          .boolean()
+          .optional()
+          .describe("Capture full page including content below the fold (default false)"),
         selector: z
           .string()
           .optional()
@@ -589,7 +671,10 @@ labels, and states — everything needed to drive browser interactions.`,
     async ({ session_id, full_page, selector }) => {
       const fetch = tfetch("browser_screenshot");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/screenshot`, { full_page, selector });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/screenshot`, {
+          full_page,
+          selector,
+        });
         if (!result.ok) return err(`Screenshot failed: ${browserError(result)}`);
         const data = result.data as { data: string; mime_type: "image/png" | "image/jpeg" };
         return {
@@ -614,7 +699,10 @@ labels, and states — everything needed to drive browser interactions.`,
       description: "Render the current page as a PDF document.",
       inputSchema: {
         session_id: sessionId,
-        print_background: z.boolean().optional().describe("Print background graphics (default false)"),
+        print_background: z
+          .boolean()
+          .optional()
+          .describe("Print background graphics (default false)"),
         landscape: z.boolean().optional().describe("Landscape orientation (default false)"),
         scale: z.number().min(0.1).max(2).optional().describe("Page scale factor (default 1)"),
       },
@@ -622,7 +710,11 @@ labels, and states — everything needed to drive browser interactions.`,
     async ({ session_id, print_background, landscape, scale }) => {
       const fetch = tfetch("browser_generate_pdf");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/generate_pdf`, { print_background, landscape, scale });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/generate_pdf`, {
+          print_background,
+          landscape,
+          scale,
+        });
         if (!result.ok) return err(`PDF generation failed: ${browserError(result)}`);
         const data = result.data as { data: string; mime_type: string };
         return {
@@ -649,17 +741,26 @@ labels, and states — everything needed to drive browser interactions.`,
     "browser_wait_for_selector",
     {
       annotations: { title: "Wait for Element", readOnlyHint: true, destructiveHint: false },
-      description: "Wait until an element matching the CSS selector is stable in the DOM. Set visible=true to also require the element to be visible (not hidden).",
+      description:
+        "Wait until an element matching the CSS selector is stable in the DOM. Set visible=true to also require the element to be visible (not hidden).",
       inputSchema: {
         session_id: sessionId,
         selector: z.string().describe("CSS selector to wait for"),
-        visible: z.boolean().optional().describe("Also require the element to be visible, not just present in the DOM (default false)"),
+        visible: z
+          .boolean()
+          .optional()
+          .describe(
+            "Also require the element to be visible, not just present in the DOM (default false)"
+          ),
       },
     },
     async ({ session_id, selector, visible }) => {
       const fetch = tfetch("browser_wait_for_selector");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/wait_for_selector`, { selector, visible });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/wait_for_selector`, {
+          selector,
+          visible,
+        });
         if (!result.ok) return err(`Wait for selector failed: ${browserError(result)}`);
         return ok();
       } catch (e) {
@@ -672,16 +773,27 @@ labels, and states — everything needed to drive browser interactions.`,
     "browser_wait_for_navigation",
     {
       annotations: { title: "Wait for Navigation", readOnlyHint: true, destructiveHint: false },
-      description: "Wait for the page to navigate to a new URL. IMPORTANT: call this BEFORE the action that triggers navigation (e.g. before browser_click on a submit button), not after — the navigation event may already have fired and this will hang until timeout. If the page stays on the same URL (AJAX/SPA), skip this tool entirely. Optional timeout_ms (default 30000ms).",
+      description:
+        "Wait for the page to navigate to a new URL. IMPORTANT: call this BEFORE the action that triggers navigation (e.g. before browser_click on a submit button), not after — the navigation event may already have fired and this will hang until timeout. If the page stays on the same URL (AJAX/SPA), skip this tool entirely. Optional timeout_ms (default 30000ms).",
       inputSchema: {
         session_id: sessionId,
-        timeout_ms: z.number().int().min(1000).max(60000).optional().describe("How long to wait in milliseconds (default 30000, max 60000)"),
+        timeout_ms: z
+          .number()
+          .int()
+          .min(1000)
+          .max(60000)
+          .optional()
+          .describe("How long to wait in milliseconds (default 30000, max 60000)"),
       },
     },
     async ({ session_id, timeout_ms }) => {
       const fetch = tfetch("browser_wait_for_navigation");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/wait_for_navigation`, timeout_ms ? { timeout_ms } : undefined);
+        const result = await fetch(
+          "POST",
+          `/browser/sessions/${session_id}/wait_for_navigation`,
+          timeout_ms ? { timeout_ms } : undefined
+        );
         if (!result.ok) return err(`Wait for navigation failed: ${browserError(result)}`);
         return json(result.data);
       } catch (e) {
@@ -694,7 +806,8 @@ labels, and states — everything needed to drive browser interactions.`,
     "browser_wait",
     {
       annotations: { title: "Wait", readOnlyHint: true, destructiveHint: false },
-      description: "Wait for a fixed duration. Use sparingly — prefer browser_wait_for_selector when possible.",
+      description:
+        "Wait for a fixed duration. Use sparingly — prefer browser_wait_for_selector when possible.",
       inputSchema: {
         session_id: sessionId,
         ms: z.number().int().min(0).max(30000).describe("Milliseconds to wait (max 30000)"),
@@ -721,7 +834,9 @@ labels, and states — everything needed to drive browser interactions.`,
       description: "Execute JavaScript in the browser context and return the result.",
       inputSchema: {
         session_id: sessionId,
-        script: z.string().describe("JavaScript expression or function body to evaluate in the page context"),
+        script: z
+          .string()
+          .describe("JavaScript expression or function body to evaluate in the page context"),
       },
     },
     async ({ session_id, script }) => {
@@ -784,7 +899,9 @@ labels, and states — everything needed to drive browser interactions.`,
       try {
         // Remap http_only → httpOnly to match Chrome DevTools Protocol / Rod's JSON field names.
         const mapped = cookies.map(({ http_only, ...rest }) => ({ ...rest, httpOnly: http_only }));
-        const result = await fetch("POST", `/browser/sessions/${session_id}/cookies`, { cookies: mapped });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/cookies`, {
+          cookies: mapped,
+        });
         if (!result.ok) return err(`Failed to set cookies: ${browserError(result)}`);
         return ok();
       } catch (e) {
@@ -821,7 +938,9 @@ labels, and states — everything needed to drive browser interactions.`,
       description: "Read, write, or clear localStorage in the current page context.",
       inputSchema: {
         session_id: sessionId,
-        action: z.enum(["get", "set", "clear"]).describe("Operation: get a value, set a value, or clear all"),
+        action: z
+          .enum(["get", "set", "clear"])
+          .describe("Operation: get a value, set a value, or clear all"),
         key: z.string().optional().describe("Storage key (required for get and set)"),
         value: z.string().optional().describe("Value to store (required for set)"),
       },
@@ -829,7 +948,11 @@ labels, and states — everything needed to drive browser interactions.`,
     async ({ session_id, action, key, value }) => {
       const fetch = tfetch("browser_local_storage");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/local_storage`, { action, key, value });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/local_storage`, {
+          action,
+          key,
+          value,
+        });
         if (!result.ok) return err(`Local storage operation failed: ${browserError(result)}`);
         return json(result.data);
       } catch (e) {
@@ -847,7 +970,11 @@ labels, and states — everything needed to drive browser interactions.`,
       description: "Open a new browser tab. Returns a tab_id to use with browser_switch_tab.",
       inputSchema: {
         session_id: sessionId,
-        url: z.string().url().optional().describe("URL to open in the new tab (opens blank tab if omitted)"),
+        url: z
+          .string()
+          .url()
+          .optional()
+          .describe("URL to open in the new tab (opens blank tab if omitted)"),
       },
     },
     async ({ session_id, url }) => {
@@ -875,7 +1002,9 @@ labels, and states — everything needed to drive browser interactions.`,
     async ({ session_id, tab_id }) => {
       const fetch = tfetch("browser_switch_tab");
       try {
-        const result = await fetch("POST", `/browser/sessions/${session_id}/switch_tab`, { tab_id });
+        const result = await fetch("POST", `/browser/sessions/${session_id}/switch_tab`, {
+          tab_id,
+        });
         if (!result.ok) return err(`Failed to switch tab: ${browserError(result)}`);
         return ok();
       } catch (e) {
@@ -893,14 +1022,23 @@ labels, and states — everything needed to drive browser interactions.`,
     z.object({ type: z.literal("reload") }),
     z.object({ type: z.literal("click"), selector: z.string() }),
     z.object({ type: z.literal("hover"), selector: z.string() }),
-    z.object({ type: z.literal("type"), selector: z.string(), text: z.string(), clear_first: z.boolean().optional() }),
+    z.object({
+      type: z.literal("type"),
+      selector: z.string(),
+      text: z.string(),
+      clear_first: z.boolean().optional(),
+    }),
     z.object({ type: z.literal("fill"), selector: z.string(), value: z.string() }),
     z.object({ type: z.literal("select"), selector: z.string(), value: z.string() }),
     z.object({ type: z.literal("check"), selector: z.string() }),
     z.object({ type: z.literal("uncheck"), selector: z.string() }),
     z.object({ type: z.literal("focus"), selector: z.string() }),
     z.object({ type: z.literal("press_key"), key: z.string() }),
-    z.object({ type: z.literal("scroll"), direction: z.enum(["up", "down", "left", "right"]), distance: z.number().optional() }),
+    z.object({
+      type: z.literal("scroll"),
+      direction: z.enum(["up", "down", "left", "right"]),
+      distance: z.number().optional(),
+    }),
     z.object({ type: z.literal("drag"), source_selector: z.string(), target_selector: z.string() }),
     z.object({ type: z.literal("get_accessibility_tree") }),
     z.object({ type: z.literal("get_url") }),
@@ -909,8 +1047,16 @@ labels, and states — everything needed to drive browser interactions.`,
     z.object({ type: z.literal("get_attribute"), selector: z.string(), attribute: z.string() }),
     z.object({ type: z.literal("get_html"), selector: z.string().optional() }),
     z.object({ type: z.literal("query_selector_all"), selector: z.string() }),
-    z.object({ type: z.literal("screenshot"), full_page: z.boolean().optional(), selector: z.string().optional() }),
-    z.object({ type: z.literal("wait_for_selector"), selector: z.string(), visible: z.boolean().optional() }),
+    z.object({
+      type: z.literal("screenshot"),
+      full_page: z.boolean().optional(),
+      selector: z.string().optional(),
+    }),
+    z.object({
+      type: z.literal("wait_for_selector"),
+      selector: z.string(),
+      visible: z.boolean().optional(),
+    }),
     z.object({ type: z.literal("wait_for_navigation") }),
     z.object({ type: z.literal("wait"), ms: z.number().int().min(0).max(30000) }),
     z.object({ type: z.literal("evaluate"), script: z.string() }),
@@ -918,7 +1064,11 @@ labels, and states — everything needed to drive browser interactions.`,
 
   type BatchAction = z.infer<typeof batchAction>;
 
-  async function runAction(action: BatchAction, session_id: string, fetch: ReturnType<typeof tfetch>): Promise<unknown> {
+  async function runAction(
+    action: BatchAction,
+    session_id: string,
+    fetch: ReturnType<typeof tfetch>
+  ): Promise<unknown> {
     const sid = session_id;
     switch (action.type) {
       case "navigate": {
@@ -942,42 +1092,62 @@ labels, and states — everything needed to drive browser interactions.`,
         return r.data;
       }
       case "click": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/click`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/click`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "hover": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/hover`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/hover`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "type": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/type`, { selector: action.selector, text: action.text, clear_first: action.clear_first });
+        const r = await fetch("POST", `/browser/sessions/${sid}/type`, {
+          selector: action.selector,
+          text: action.text,
+          clear_first: action.clear_first,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "fill": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/fill`, { selector: action.selector, value: action.value });
+        const r = await fetch("POST", `/browser/sessions/${sid}/fill`, {
+          selector: action.selector,
+          value: action.value,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "select": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/select`, { selector: action.selector, value: action.value });
+        const r = await fetch("POST", `/browser/sessions/${sid}/select`, {
+          selector: action.selector,
+          value: action.value,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "check": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/check`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/check`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "uncheck": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/uncheck`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/uncheck`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "focus": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/focus`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/focus`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
@@ -987,12 +1157,18 @@ labels, and states — everything needed to drive browser interactions.`,
         return { ok: true };
       }
       case "scroll": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/scroll`, { direction: action.direction, distance: action.distance });
+        const r = await fetch("POST", `/browser/sessions/${sid}/scroll`, {
+          direction: action.direction,
+          distance: action.distance,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
       case "drag": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/drag`, { source_selector: action.source_selector, target_selector: action.target_selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/drag`, {
+          source_selector: action.source_selector,
+          target_selector: action.target_selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
@@ -1012,27 +1188,39 @@ labels, and states — everything needed to drive browser interactions.`,
         return r.data;
       }
       case "get_text": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/get_text`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/get_text`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return (r.data as { text: string }).text;
       }
       case "get_attribute": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/get_attribute`, { selector: action.selector, attribute: action.attribute });
+        const r = await fetch("POST", `/browser/sessions/${sid}/get_attribute`, {
+          selector: action.selector,
+          attribute: action.attribute,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return r.data;
       }
       case "get_html": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/get_html`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/get_html`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return (r.data as { html: string }).html;
       }
       case "query_selector_all": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/query_selector_all`, { selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/query_selector_all`, {
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return r.data;
       }
       case "screenshot": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/screenshot`, { full_page: action.full_page, selector: action.selector });
+        const r = await fetch("POST", `/browser/sessions/${sid}/screenshot`, {
+          full_page: action.full_page,
+          selector: action.selector,
+        });
         if (!r.ok) throw new Error(browserError(r));
         // Return as data URI string so it fits in the JSON result array.
         // For proper image rendering, use browser_screenshot directly.
@@ -1040,7 +1228,10 @@ labels, and states — everything needed to drive browser interactions.`,
         return { mime_type: d.mime_type, data: d.data };
       }
       case "wait_for_selector": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/wait_for_selector`, { selector: action.selector, visible: action.visible });
+        const r = await fetch("POST", `/browser/sessions/${sid}/wait_for_selector`, {
+          selector: action.selector,
+          visible: action.visible,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return { ok: true };
       }
@@ -1055,7 +1246,9 @@ labels, and states — everything needed to drive browser interactions.`,
         return { ok: true };
       }
       case "evaluate": {
-        const r = await fetch("POST", `/browser/sessions/${sid}/evaluate`, { script: action.script });
+        const r = await fetch("POST", `/browser/sessions/${sid}/evaluate`, {
+          script: action.script,
+        });
         if (!r.ok) throw new Error(browserError(r));
         return r.data;
       }
@@ -1065,7 +1258,11 @@ labels, and states — everything needed to drive browser interactions.`,
   server.registerTool(
     "browser_batch",
     {
-      annotations: { title: "Run Batch of Browser Actions", readOnlyHint: false, destructiveHint: false },
+      annotations: {
+        title: "Run Batch of Browser Actions",
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
       description: `Execute a sequence of browser actions in a single call against an existing session.
 
 Use this when you already know the full sequence of steps — it reduces round trips and
@@ -1078,10 +1275,17 @@ Note: screenshots in batch results are returned as base64 strings inside the JSO
 For proper image rendering, use browser_screenshot directly.`,
       inputSchema: {
         session_id: sessionId,
-        actions: z.array(batchAction).min(1).max(50).describe(
-          "Ordered list of actions to perform. Each action has a 'type' field plus type-specific parameters."
-        ),
-        stop_on_error: z.boolean().optional().describe("Stop executing on the first failed action (default true)"),
+        actions: z
+          .array(batchAction)
+          .min(1)
+          .max(50)
+          .describe(
+            "Ordered list of actions to perform. Each action has a 'type' field plus type-specific parameters."
+          ),
+        stop_on_error: z
+          .boolean()
+          .optional()
+          .describe("Stop executing on the first failed action (default true)"),
       },
     },
     async ({ session_id, actions, stop_on_error = true }) => {
@@ -1098,7 +1302,12 @@ For proper image rendering, use browser_screenshot directly.`,
           results.push({ step: i, type: action.type, error: msg });
           if (stop_on_error) {
             return {
-              content: [{ type: "text" as const, text: JSON.stringify({ completed: i, total: actions.length, results }) }],
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ completed: i, total: actions.length, results }),
+                },
+              ],
               isError: true as const,
             };
           }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BROWSER_SCOPES, clearIntrospectionCache, guardScopes, scrapeScopes } from "../src/auth.ts";
+
+type FetchResponse = { ok: boolean; json: () => Promise<unknown> };
+
+function stubFetch(response: FetchResponse | (() => never)): void {
+  globalThis.fetch = (async () => {
+    if (typeof response === "function") return response();
+    return response;
+  }) as typeof fetch;
+}
+
+function withScopes(scopes: string[]): FetchResponse {
+  return { ok: true, json: async () => ({ data: { scopes } }) };
+}
+
+const LEGACY_KEY_401: FetchResponse = { ok: false, json: async () => ({}) };
+
+test("legacy (non-agent) keys are not scope-gated", async () => {
+  clearIntrospectionCache();
+  stubFetch(LEGACY_KEY_401);
+  assert.equal(await guardScopes("legacy-key-1", BROWSER_SCOPES), null);
+});
+
+test("scoped credential with the required scope is allowed", async () => {
+  clearIntrospectionCache();
+  stubFetch(withScopes(["scrape:write", "browser:session_write"]));
+  assert.equal(await guardScopes("agent-key-1", BROWSER_SCOPES), null);
+});
+
+test("scoped credential missing a scope is denied with a helpful message", async () => {
+  clearIntrospectionCache();
+  stubFetch(withScopes(["scrape:write"]));
+  const denial = await guardScopes("agent-key-2", BROWSER_SCOPES);
+  assert.ok(denial);
+  assert.match(denial!, /insufficient_scope/);
+  assert.match(denial!, /browser:session_write/);
+});
+
+test("introspection outage fails open to pass-through", async () => {
+  clearIntrospectionCache();
+  stubFetch(() => {
+    throw new Error("network down");
+  });
+  assert.equal(await guardScopes("agent-key-3", ["scrape:write"]), null);
+});
+
+test("scrapeScopes requires extract:json only for structured extraction", () => {
+  assert.deepEqual(scrapeScopes({}), ["scrape:write"]);
+  assert.deepEqual(scrapeScopes({ autoparse: true }), ["scrape:write", "extract:json"]);
+  assert.deepEqual(scrapeScopes({ css_extractor: '{"t":"h1"}' }), ["scrape:write", "extract:json"]);
+});


### PR DESCRIPTION
## What

Adds **per-tool scope enforcement** for scoped ZenRows agent credentials, while keeping existing full-access API keys working exactly as before.

The ZenRows app now issues scoped, revocable, expiring **agent credentials** (via OAuth / CLI / OTP / ID-JAG) and exposes a credential-introspection endpoint. This MCP server already passes a presented credential straight through to the Scraper/Browser APIs and already advertises the OAuth discovery metadata — so scoped credentials already *flow through*. The missing piece was enforcing what each credential is allowed to do.

## How

- **`src/auth.ts`** — `introspect(apiKey)` calls `GET /me/credential`:
  - `200` → a scoped agent credential; enforce its scopes.
  - `401` (legacy user API key, or revoked/invalid) → no scope data; **pass through** unchanged (a truly invalid key is still rejected by the Scraper API on use).
  - introspection outage → **fail open** to pass-through (availability; the API backstops).
  - 60s per-key cache so we don't introspect on every tool call.
- **Scope map**: `scrape` requires `scrape:write` (+ `extract:json` when `autoparse`/`css_extractor`/`outputs` is used); all `browser_*` tools require `browser:session_write` (a production scope requiring approval) — gated once in the shared `tfetch`, so all 30+ browser tools are covered without per-handler edits.
- Denials return an `insufficient_scope` message pointing to **Settings → Agents**.
- `ZENROWS_INTROSPECTION_URL` config (default `https://api.zenrows.com/me/credential`).

## Compatibility

Fully backward compatible: plain API keys are never scope-gated (introspection returns 401 → pass-through). Only OAuth-issued agent credentials are enforced.

## Tests

Adds a `node --test` harness + `test` script. `npm run typecheck`, `npm run lint`, and `npm test` (5 tests) all pass. Zero new runtime dependencies.