### PR TITLE
feat: add extract, batch tools, and stdio auto-signup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
+# Optional for stdio: if unset, auto-signup provisions a Free plan into ~/.zenrows/
+# Set ZENROWS_AUTO_SIGNUP=false to require an explicit key.
 ZENROWS_API_KEY=your_api_key_here
+
+# Optional: disable stdio auto-signup (default: enabled when key missing)
+# ZENROWS_AUTO_SIGNUP=false
 
 # Optional: enable browser tools
 # ZENROWS_BROWSER_URL=http://localhost:12345

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    name: node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
 
       # Dockerfile COPY's dist/ + node_modules/ from the build context.
       - run: npm ci
+      - run: npm test
       - run: npm run build
 
       - name: Log in to GHCR
@@ -80,7 +81,7 @@ jobs:
           cache: "npm"
 
       - run: npm ci
-
+      - run: npm test
       - run: npm run build
 
       # No NODE_AUTH_TOKEN — npm uses GitHub OIDC against the Trusted Publisher

--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ https://mcp.zenrows.com/mcp
 
 **Transport:** Streamable HTTP
 
-**Authentication:** OAuth-based. Pass your Zenrows API key as a Bearer token in the `Authorization` header on every request.
+**Authentication:** OAuth or API key as Bearer token. Pass your Zenrows API key in the `Authorization` header on every request (or complete OAuth in clients that support it).
 
 ```
 Authorization: Bearer YOUR_ZENROWS_API_KEY
 ```
 
 Most MCP clients accept this through an `authorization` shorthand field on the tool config and forward it as the Bearer token automatically. Some clients use a free-form `headers` field instead. Either approach works.
+
+> Remote MCP does **not** auto-create accounts. Use OAuth “Create Free account” in the client, or pass an existing API key.
 
 #### Example: OpenAI Responses API
 
@@ -84,11 +86,15 @@ Use the local stdio configuration when your MCP client runs the server as a loca
 
 **Package:** [`@zenrows/mcp`](https://www.npmjs.com/package/@zenrows/mcp) on npm
 
-**Authentication:** API key via the `ZENROWS_API_KEY` environment variable.
+**Authentication:**
+
+1. `ZENROWS_API_KEY` environment variable, or
+2. Key previously stored in `~/.zenrows/secrets.json`, or
+3. **Auto-signup** (default): if neither is set, stdio provisions a Free plan account via `POST /api/agent/signup`, persists the key + claim metadata under `~/.zenrows/` (`secrets.json` + `account.json`, mode `0600`), and prints a claim URL on stderr. Opt out with `ZENROWS_AUTO_SIGNUP=false`.
 
 **Requirements:** [Node.js](https://nodejs.org/) installed (for `npx` to work).
 
-**Configuration:**
+**Configuration (with your own key):**
 
 ```json
 {
@@ -104,16 +110,33 @@ Use the local stdio configuration when your MCP client runs the server as a loca
 }
 ```
 
+**Zero-config (auto-signup):**
+
+```json
+{
+  "mcpServers": {
+    "zenrows": {
+      "command": "npx",
+      "args": ["-y", "@zenrows/mcp"]
+    }
+  }
+}
+```
+
 The exact location of this config varies by client. See the [per-client setup guides](https://docs.zenrows.com/mcp/overview#per-client-setup-guides) for the file path for your client.
 
 ---
 
 ## Tools
 
-The Zenrows MCP exposes two families of tools:
+The Zenrows MCP exposes these tool families:
 
-- **`scrape`**: single-request fetch returning Markdown, plain text, HTML, JSON, PDF, or screenshot. Backed by [Fetch](https://docs.zenrows.com/fetch/api-reference).
-- **`browser_*`**: 30+ tools for full browser automation including navigation, clicks, form fills, JavaScript execution, cookies, tabs, and persistent sessions. Backed by [Browser Sessions](https://docs.zenrows.com/browser-sessions/introduction).
+| Tool | Purpose |
+|------|---------|
+| **`scrape`** | Full-page content → Markdown, plain text, HTML, PDF, or screenshot (plus helper outputs). |
+| **`extract`** | Structured JSON (`extract=auto`, autoparse, or `css_extractor`) + optional stealth flags. `extract=auto` is open beta (currently free; billing may apply later). |
+| **`batch_create` / `batch_status` / `batch_results` / `batch_cancel` / `batch_wait`** | Cloud Batch API fan-out (`async.api.zenrows.com`). Beta; may return `BATCH_ACCESS_DENIED`. Not `browser_batch`. |
+| **`browser_*`** | 30+ tools for full browser automation (navigation, clicks, forms, JS, cookies, tabs, sessions). |
 
 The AI selects the right tool from your prompt. You don't call tools directly in code.
 
@@ -127,7 +150,7 @@ See the [full tool reference](https://docs.zenrows.com/mcp/overview#tools) for e
 git clone https://github.com/ZenRows/zenrows-mcp
 cd zenrows-mcp
 npm install
-cp .env.example .env   # Add your API key
+cp .env.example .env   # Optional: add your API key (stdio can auto-signup)
 npm run dev            # Run with .env loaded (requires Node.js 20.6+)
 npm run build          # Compile to dist/
 npm run inspect        # Open the MCP inspector UI

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run clean && npm run build && npm run typecheck && npm run lint",
+    "prepublishOnly": "npm run clean && npm run build && npm run typecheck && npm run lint && npm test",
     "publish-beta": "npm publish --tag beta",
     "test": "node --import tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zenrows/mcp",
   "version": "2.1.2",
-  "description": "Zenrows MCP server — Fetch and Browser Sessions for AI coding assistants",
+  "description": "Zenrows MCP server — Fetch, Extract, Batch, and Browser Sessions for AI coding assistants",
   "type": "module",
   "bin": {
     "zenrows-mcp": "dist/index.js"
@@ -22,6 +22,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm run clean && npm run build && npm run typecheck && npm run lint",
     "publish-beta": "npm publish --tag beta",
+    "test": "node --import tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/src/auth/ensure-key.ts
+++ b/src/auth/ensure-key.ts
@@ -1,0 +1,223 @@
+/**
+ * Resolve-or-provision the Zenrows API key for stdio MCP.
+ *
+ * Persistence lives under ~/.zenrows/ (secrets.json + account.json, mode 0600).
+ * Remote HTTP transport must NOT call this — Bearer/OAuth only.
+ */
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const ENV_KEY = "ZENROWS_API_KEY";
+export const AUTO_SIGNUP_ENV = "ZENROWS_AUTO_SIGNUP";
+export const SIGNUP_URL_ENV = "ZENROWS_AGENT_SIGNUP_URL";
+export const DISCOVERY_URL_ENV = "ZENROWS_DISCOVERY_URL";
+
+export const AGENT_SIGNUP_API_URL = "https://app.zenrows.com/api/agent/signup";
+export const WELL_KNOWN_PROTECTED_RESOURCE = "/.well-known/oauth-protected-resource";
+
+export interface AgentAccount {
+  accountId: string;
+  unclaimed: boolean;
+  claimUrl: string;
+  createdAt: string;
+}
+
+export interface SignupResponse {
+  apiKey: string;
+  accountId: string;
+  claimUrl: string;
+}
+
+export class AuthError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "AuthError";
+    this.code = code;
+  }
+}
+
+/** Override home for tests / custom installs (absolute path to the `.zenrows` dir parent, or the dir itself if it ends with `.zenrows`). */
+export const ZENROWS_HOME_ENV = "ZENROWS_HOME";
+
+function zenrowsDir(): string {
+  const override = process.env[ZENROWS_HOME_ENV]?.trim();
+  if (override) {
+    return override.endsWith(".zenrows") ? override : join(override, ".zenrows");
+  }
+  return join(homedir(), ".zenrows");
+}
+
+/** Test-only: clear discovery cache between cases. */
+export function _resetDiscoveryCache(): void {
+  discoveredSignupUrl = undefined;
+}
+
+export function getZenrowsDir(): string {
+  return zenrowsDir();
+}
+
+function secretsPath(): string {
+  return join(zenrowsDir(), "secrets.json");
+}
+
+function accountPath(): string {
+  return join(zenrowsDir(), "account.json");
+}
+
+function ensureDir(): void {
+  const dir = zenrowsDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+function readJsonFile<T>(file: string): T | null {
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonSecure(file: string, data: unknown): void {
+  ensureDir();
+  writeFileSync(file, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
+  try {
+    chmodSync(file, 0o600);
+  } catch {
+    // best-effort on platforms without POSIX permissions
+  }
+}
+
+export function readStoredApiKey(): string | undefined {
+  const stored = readJsonFile<{ apiKey?: string }>(secretsPath());
+  const key = stored?.apiKey?.trim();
+  return key || undefined;
+}
+
+export function readAccount(): AgentAccount | null {
+  return readJsonFile<AgentAccount>(accountPath());
+}
+
+export function saveApiKey(apiKey: string): void {
+  writeJsonSecure(secretsPath(), { apiKey: apiKey.trim() });
+}
+
+export function writeAccount(acct: AgentAccount): void {
+  writeJsonSecure(accountPath(), acct);
+}
+
+/** Resolve key: env → ~/.zenrows/secrets.json. Does not signup. */
+export function resolveApiKey(): { key?: string; source: "env" | "secrets-file" | "none" } {
+  const env = process.env[ENV_KEY]?.trim();
+  if (env) return { key: env, source: "env" };
+  const stored = readStoredApiKey();
+  if (stored) return { key: stored, source: "secrets-file" };
+  return { source: "none" };
+}
+
+export function autoSignupEnabled(): boolean {
+  return process.env[AUTO_SIGNUP_ENV] !== "false";
+}
+
+let discoveredSignupUrl: string | null | undefined;
+
+export async function discoverSignupUrl(opts: { fetchImpl?: typeof fetch } = {}): Promise<string | null> {
+  try {
+    const base =
+      process.env[DISCOVERY_URL_ENV]?.trim() || new URL(AGENT_SIGNUP_API_URL).origin;
+    const url = base.replace(/\/$/, "") + WELL_KNOWN_PROTECTED_RESOURCE;
+    const doFetch = opts.fetchImpl ?? fetch;
+    const res = await doFetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json", "User-Agent": "zenrows/mcp" },
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { agent_auth?: { signup_endpoint?: unknown } };
+    const endpoint = json?.agent_auth?.signup_endpoint;
+    if (typeof endpoint === "string" && endpoint.trim()) return endpoint.trim();
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function signupCandidates(opts: { fetchImpl?: typeof fetch } = {}): Promise<string[]> {
+  const fromEnv = process.env[SIGNUP_URL_ENV];
+  if (fromEnv && fromEnv.trim()) return [fromEnv.trim()];
+  if (discoveredSignupUrl === undefined) {
+    discoveredSignupUrl = await discoverSignupUrl(opts);
+  }
+  const urls: string[] = [];
+  if (discoveredSignupUrl && discoveredSignupUrl !== AGENT_SIGNUP_API_URL) {
+    urls.push(discoveredSignupUrl);
+  }
+  urls.push(AGENT_SIGNUP_API_URL);
+  return urls;
+}
+
+export async function signupAgent(
+  opts: { url?: string; fetchImpl?: typeof fetch; userAgent?: string } = {}
+): Promise<SignupResponse> {
+  const urls = opts.url ? [opts.url] : await signupCandidates({ fetchImpl: opts.fetchImpl });
+  const doFetch = opts.fetchImpl ?? fetch;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "User-Agent": opts.userAgent ?? "zenrows/mcp",
+    "X-ZR-Source": "mcp",
+  };
+
+  let lastMessage = "No signup endpoint was reachable.";
+  for (const url of urls) {
+    let res: Response;
+    try {
+      res = await doFetch(url, { method: "POST", headers });
+    } catch (err) {
+      lastMessage = err instanceof Error ? err.message : String(err);
+      continue;
+    }
+    if (res.status === 201) return (await res.json()) as SignupResponse;
+    const body = await res.text();
+    if (res.status === 429) {
+      throw new AuthError(
+        "SIGNUP_RATE_LIMITED",
+        "Zenrows blocked auto-signup: too many new accounts from this network. Wait and retry, or set ZENROWS_API_KEY."
+      );
+    }
+    lastMessage = `HTTP ${res.status}: ${body.slice(0, 240)}`;
+  }
+  throw new AuthError("SIGNUP_FAILED", `Automatic account provisioning failed. ${lastMessage}`);
+}
+
+/**
+ * Ensure an API key is available for stdio.
+ * Returns the key and optional claim metadata when a new account was provisioned.
+ */
+export async function ensureApiKey(opts: {
+  fetchImpl?: typeof fetch;
+  userAgent?: string;
+  onProvision?: (a: AgentAccount) => void;
+} = {}): Promise<{ apiKey: string; provisioned?: AgentAccount }> {
+  const existing = resolveApiKey();
+  if (existing.key) return { apiKey: existing.key };
+
+  if (!autoSignupEnabled()) {
+    throw new AuthError(
+      "AUTH_MISSING",
+      "ZENROWS_API_KEY is required (auto-signup disabled via ZENROWS_AUTO_SIGNUP=false)."
+    );
+  }
+
+  const res = await signupAgent({ fetchImpl: opts.fetchImpl, userAgent: opts.userAgent });
+  saveApiKey(res.apiKey);
+  const account: AgentAccount = {
+    accountId: res.accountId,
+    unclaimed: true,
+    claimUrl: res.claimUrl,
+    createdAt: new Date().toISOString(),
+  };
+  writeAccount(account);
+  opts.onProvision?.(account);
+  return { apiKey: res.apiKey, provisioned: account };
+}

--- a/src/batch-api.ts
+++ b/src/batch-api.ts
@@ -1,0 +1,258 @@
+/**
+ * Client for the Zenrows Batch API (https://async.api.zenrows.com/v1).
+ * Auth via X-API-Key header. Errors are application/problem+json (RFC 7807).
+ */
+
+export const DEFAULT_BATCH_API_BASE = "https://async.api.zenrows.com/v1";
+export const BATCH_API_BASE_ENV = "ZENROWS_BATCH_API_BASE";
+
+export function batchBase(): string {
+  const env = process.env[BATCH_API_BASE_ENV];
+  const base = env && env.trim() ? env.trim() : DEFAULT_BATCH_API_BASE;
+  return base.replace(/\/+$/, "");
+}
+
+export interface JobStats {
+  total: number;
+  completed: number;
+  successful: number;
+  failed: number;
+}
+
+export interface JobRun {
+  status: string;
+  stats: JobStats;
+  run_id?: string;
+  [k: string]: unknown;
+}
+
+export interface Job {
+  job_id: string;
+  latest_run: JobRun;
+  [k: string]: unknown;
+}
+
+export interface ResultRow {
+  external_id?: string;
+  task_id: string;
+  status?: string;
+  result_url?: string;
+  [k: string]: unknown;
+}
+
+export interface ResultsPage {
+  results: ResultRow[];
+  next_cursor: string | null;
+}
+
+export interface ProblemJson {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  code?: string;
+  invalid_tasks?: Array<{ index: number; reason: string }>;
+}
+
+export const TERMINAL_STATUSES: ReadonlySet<string> = new Set(["completed", "stopped", "deleted"]);
+
+export class BatchError extends Error {
+  code: string;
+  status?: number;
+  detail?: string;
+
+  constructor(opts: { code: string; message: string; status?: number; detail?: string }) {
+    super(opts.message);
+    this.name = "BatchError";
+    this.code = opts.code;
+    this.status = opts.status;
+    this.detail = opts.detail;
+  }
+
+  toJSON(): { code: string; message: string; status?: number; detail?: string } {
+    return { code: this.code, message: this.message, status: this.status, detail: this.detail };
+  }
+}
+
+interface RequestOpts {
+  apiKey: string;
+  body?: unknown;
+  query?: Record<string, string | undefined>;
+  timeoutMs?: number;
+  userAgent?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function batchRequest<T>(method: string, path: string, opts: RequestOpts): Promise<T> {
+  const url = new URL(batchBase() + path);
+  for (const [k, v] of Object.entries(opts.query ?? {})) {
+    if (v !== undefined && v !== null) url.searchParams.set(k, v);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs ?? 60_000);
+  const headers: Record<string, string> = {
+    "X-API-Key": opts.apiKey,
+    Accept: "application/json",
+    "User-Agent": opts.userAgent ?? "zenrows/mcp",
+  };
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
+
+  const doFetch = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch(url.toString(), {
+      method,
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timeout);
+    throw new BatchError({
+      code: "BACKEND_UNAVAILABLE",
+      message: `Could not reach the Zenrows Batch API: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  }
+  clearTimeout(timeout);
+
+  const text = await res.text();
+  if (res.status < 200 || res.status >= 300) {
+    throw problemToError(res.status, text, method, path);
+  }
+  if (!text) return null as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new BatchError({
+      code: "BATCH_FAILED",
+      message: "The Batch API response was not valid JSON.",
+      detail: text.slice(0, 240),
+    });
+  }
+}
+
+function problemToError(status: number, body: string, method: string, path: string): BatchError {
+  let problem: ProblemJson = {};
+  try {
+    problem = JSON.parse(body) as ProblemJson;
+  } catch {
+    // non-JSON — fall through
+  }
+  const serverCode = problem.code ?? "";
+  const detail = problem.detail || problem.title || body.slice(0, 240) || `HTTP ${status}`;
+  const cause = `HTTP ${status}${serverCode ? ` (${serverCode})` : ""} for ${method} ${path}: ${detail}`;
+
+  if (status === 403) {
+    return new BatchError({
+      code: "BATCH_ACCESS_DENIED",
+      message:
+        "The Batch API rejected this request (access denied). The Batch API is in beta and this account does not have beta access. Request access from Zenrows, or fan out with scrape/extract per URL.",
+      status,
+      detail: cause,
+    });
+  }
+  if (status === 401) {
+    return new BatchError({
+      code: "AUTH_INVALID",
+      message: "Zenrows rejected the API key for the Batch API.",
+      status,
+      detail: cause,
+    });
+  }
+  if (status === 404) {
+    return new BatchError({
+      code: "BATCH_NOT_FOUND",
+      message: "Batch job, run, or task not found.",
+      status,
+      detail: cause,
+    });
+  }
+  if (status === 429) {
+    return new BatchError({
+      code: "BATCH_QUOTA_EXCEEDED",
+      message:
+        "Batch quota exceeded (e.g. max concurrent active jobs). Wait for an in-flight job to finish or cancel one, then retry.",
+      status,
+      detail: cause,
+    });
+  }
+  if (status === 402) {
+    return new BatchError({
+      code: "BATCH_QUOTA_EXCEEDED",
+      message: "Subscription has no credit available for the Batch API.",
+      status,
+      detail: cause,
+    });
+  }
+
+  const invalid = problem.invalid_tasks?.length
+    ? ` invalid_tasks: ${problem.invalid_tasks
+        .slice(0, 10)
+        .map((t) => `#${t.index}: ${t.reason}`)
+        .join("; ")}`
+    : "";
+  return new BatchError({
+    code: "BATCH_FAILED",
+    message: `Batch request failed (HTTP ${status}).${invalid}`,
+    status,
+    detail: cause,
+  });
+}
+
+interface CallOpts {
+  apiKey: string;
+  timeoutMs?: number;
+  userAgent?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export function createJob(body: unknown, opts: CallOpts): Promise<Job> {
+  return batchRequest<Job>("POST", "/jobs", { ...opts, body });
+}
+
+export function getJob(id: string, opts: CallOpts): Promise<Job> {
+  return batchRequest<Job>("GET", `/jobs/${encodeURIComponent(id)}`, opts);
+}
+
+export function stopJob(id: string, opts: CallOpts): Promise<Job> {
+  return batchRequest<Job>("POST", `/jobs/${encodeURIComponent(id)}/stop`, opts);
+}
+
+export async function listResults(
+  id: string,
+  opts: CallOpts & { status?: "successful" | "failed" | "all" }
+): Promise<ResultRow[]> {
+  const all: ResultRow[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await batchRequest<ResultsPage>("GET", `/jobs/${encodeURIComponent(id)}/results`, {
+      ...opts,
+      query: { status: opts.status, cursor },
+    });
+    if (page?.results) all.push(...page.results);
+    cursor = page?.next_cursor ?? undefined;
+  } while (cursor);
+  return all;
+}
+
+export async function waitForJob(
+  id: string,
+  opts: CallOpts & { pollTimeoutMs?: number }
+): Promise<Job> {
+  const deadline = Date.now() + (opts.pollTimeoutMs ?? opts.timeoutMs ?? 600_000);
+  let delay = 2000;
+  for (;;) {
+    const job = await getJob(id, opts);
+    if (job.latest_run && TERMINAL_STATUSES.has(job.latest_run.status)) return job;
+    if (Date.now() > deadline) {
+      throw new BatchError({
+        code: "BATCH_FAILED",
+        message: `Timed out waiting for batch job ${id} to finish.`,
+        detail: `The run did not reach a terminal state within ${Math.round((opts.pollTimeoutMs ?? opts.timeoutMs ?? 600_000) / 1000)}s.`,
+      });
+    }
+    await new Promise<void>((r) => setTimeout(r, delay));
+    delay = Math.min(delay * 1.5, 15_000);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,54 @@
 #!/usr/bin/env node
+import { createRequire } from "module";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  AuthError,
+  ensureApiKey,
+  getZenrowsDir,
+  resolveApiKey,
+} from "./auth/ensure-key.js";
 import { createServer } from "./server.js";
 
-const apiKey = process.env.ZENROWS_API_KEY;
-if (!apiKey) {
-  process.stderr.write("Error: ZENROWS_API_KEY environment variable is required\n");
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+let apiKey: string;
+try {
+  const existing = resolveApiKey();
+  if (existing.key) {
+    process.stderr.write(
+      `Using existing API key from ${existing.source} (secrets dir: ${getZenrowsDir()})\n`
+    );
+  } else {
+    const signup =
+      process.env.ZENROWS_AGENT_SIGNUP_URL?.trim() ||
+      "https://app.zenrows.com/api/agent/signup (default prod)";
+    process.stderr.write(`No API key — will auto-signup via: ${signup}\n`);
+  }
+
+  const resolved = await ensureApiKey({
+    userAgent: `zenrows/mcp ${pkg.version}`,
+    onProvision: (acct) => {
+      process.stderr.write(
+        `Created a Zenrows Free plan account.\n` +
+          `Claim it anytime (keeps your usage): ${acct.claimUrl}\n` +
+          `Key stored in ${getZenrowsDir()}/secrets.json\n`
+      );
+    },
+  });
+  apiKey = resolved.apiKey;
+} catch (err) {
+  const msg =
+    err instanceof AuthError
+      ? `Error: ${err.message}\n`
+      : `Error: ${err instanceof Error ? err.message : String(err)}\n`;
+  process.stderr.write(msg);
   process.exit(1);
 }
 
 const server = createServer(apiKey);
 const transport = new StdioServerTransport();
 await server.connect(transport);
-process.stderr.write("Zenrows MCP server running on stdio\n");
+process.stderr.write(
+  `Zenrows MCP server running on stdio (secrets dir: ${getZenrowsDir()})\n`
+);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,10 @@
 import { createRequire } from "module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
+import { getZenrowsDir, readAccount } from "./auth/ensure-key.js";
+import { registerBatchTools } from "./tools/batch.js";
 import { registerBrowserTools } from "./tools/browser.js";
+import { registerExtractTool } from "./tools/extract.js";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../package.json") as { version: string };
@@ -33,24 +36,22 @@ export function createServer(apiKey: string, clientName?: string): McpServer {
         readOnlyHint: true,
         destructiveHint: false,
       },
-      description: `Scrape any webpage and return its content using Zenrows.
+      description: `Scrape any webpage and return its content using Zenrows (Fetch).
 
-Use this tool to fetch webpage content for analysis. By default it returns clean
-markdown, which is ideal for LLM processing.
+Use for full-page content (markdown/HTML/PDF/screenshot). For structured JSON
+fields (products, articles, listings), prefer the extract tool when it fits —
+it returns parsed fields instead of a full page body.
 
 When to enable options:
 - js_render: page uses React/Vue/Angular, loads content dynamically, or content
   appears missing on the first attempt
 - premium_proxy: site returns 403/blocked errors even with js_render enabled
 - wait_for: specific content loads after initial render (requires js_render)
-- css_extractor: you only need specific elements, not the whole page
-- autoparse: structured data pages like products or articles
 
 Examples:
   Basic:    { url: "https://example.com" }
   Dynamic:  { url: "https://spa.com", js_render: true }
-  Protected:{ url: "https://protected.com", js_render: true, premium_proxy: true }
-  Extract:  { url: "https://shop.com", css_extractor: '{"title":"h1","price":".price"}' }`,
+  Protected:{ url: "https://protected.com", js_render: true, premium_proxy: true }`,
       inputSchema: {
         url: z.string().url().describe("The webpage URL to scrape"),
 
@@ -295,7 +296,7 @@ Examples:
     "extract_structured_data",
     {
       title: "Extract Structured Data",
-      description: "Scrape a webpage and extract specific structured data using CSS selectors.",
+      description: "Extract specific structured data from a webpage using CSS selectors.",
       argsSchema: {
         url: z.string().url().describe("The webpage URL to extract data from"),
         fields: z
@@ -311,7 +312,7 @@ Examples:
           role: "user",
           content: {
             type: "text",
-            text: `Scrape ${url} using the Zenrows MCP scrape tool with css_extractor set to ${fields}. Return the extracted data as a clean JSON object.`,
+            text: `Use the Zenrows MCP extract tool on ${url} with mode=css and css_extractor set to ${fields}. Return the extracted data as a clean JSON object.`,
           },
         },
       ],
@@ -341,8 +342,48 @@ Examples:
     })
   );
 
+  registerExtractTool(server, apiKey, getClientName);
+  registerBatchTools(server, apiKey);
+
   const BROWSER_URL = process.env.ZENROWS_BROWSER_URL ?? "https://mcp.zenrows.com";
   registerBrowserTools(server, apiKey, BROWSER_URL, getClientName);
+
+  // Always expose account resource; handler re-reads disk so ZENROWS_HOME is visible.
+  server.registerResource(
+    "zenrows-account",
+    "zenrows://account",
+    {
+      description:
+        "Local Zenrows agent account metadata (claim URL for unclaimed Free plans). Re-reads ~/.zenrows or $ZENROWS_HOME on each read.",
+      mimeType: "application/json",
+    },
+    async () => {
+      const acct = readAccount();
+      const home = getZenrowsDir();
+      const body = acct
+        ? {
+            accountId: acct.accountId,
+            unclaimed: acct.unclaimed,
+            claimUrl: acct.claimUrl,
+            createdAt: acct.createdAt,
+            zenrowsHome: home,
+          }
+        : {
+            unclaimed: false,
+            message: "No local agent account file (key from env or missing).",
+            zenrowsHome: home,
+          };
+      return {
+        contents: [
+          {
+            uri: "zenrows://account",
+            mimeType: "application/json",
+            text: JSON.stringify(body, null, 2),
+          },
+        ],
+      };
+    }
+  );
 
   return server;
 }

--- a/src/tools/batch.ts
+++ b/src/tools/batch.ts
@@ -1,0 +1,288 @@
+import { createRequire } from "module";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  BatchError,
+  createJob,
+  getJob,
+  listResults,
+  stopJob,
+  waitForJob,
+} from "../batch-api.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
+
+type TextContent = { type: "text"; text: string };
+
+function err(data: unknown): { content: TextContent[]; isError: true } {
+  return {
+    content: [{ type: "text" as const, text: typeof data === "string" ? data : JSON.stringify(data) }],
+    isError: true as const,
+  };
+}
+
+function json(data: unknown): { content: TextContent[] } {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+function batchErr(e: unknown): { content: TextContent[]; isError: true } {
+  if (e instanceof BatchError) return err(e.toJSON());
+  return err({
+    code: "BATCH_FAILED",
+    message: e instanceof Error ? e.message : String(e),
+  });
+}
+
+function normalizeParams(obj: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    if (typeof v === "string") out[k] = v;
+    else if (typeof v === "boolean" || typeof v === "number") out[k] = String(v);
+    else out[k] = JSON.stringify(v);
+  }
+  return out;
+}
+
+const taskSchema = z.object({
+  url: z.string().url().describe("Target URL for this task"),
+  external_id: z.string().optional().describe("Optional stable id echoed back on results"),
+  metadata: z.unknown().optional().describe("Opaque per-task metadata carried through to results"),
+  zenrows_params: z
+    .record(z.union([z.string(), z.number(), z.boolean()]))
+    .optional()
+    .describe("Per-task Zenrows scrape params (js_render, premium_proxy, extract, autoparse, …)"),
+});
+
+export function registerBatchTools(server: McpServer, apiKey: string): void {
+  const ua = `zenrows/mcp ${pkg.version}`;
+  const call = { apiKey, userAgent: ua };
+
+  server.registerTool(
+    "batch_create",
+    {
+      annotations: { title: "Create Batch Job", readOnlyHint: false, destructiveHint: false },
+      description: `Submit a cloud Batch job that fans out many URLs asynchronously (Zenrows Batch API beta).
+
+NOT the same as browser_batch — this hits https://async.api.zenrows.com/v1 with X-API-Key.
+Use for large URL lists; prefer scrape/extract for one-off pages.
+
+Returns job_id + latest_run.status/stats. Poll with batch_status / batch_wait, then batch_results.
+If you get BATCH_ACCESS_DENIED, the account lacks Batch beta access.`,
+      inputSchema: {
+        tasks: z
+          .array(taskSchema)
+          .optional()
+          .describe("List of tasks (each needs a url). Prefer this over urls when you need per-task params."),
+        urls: z
+          .array(z.string().url())
+          .optional()
+          .describe("Shorthand: list of URLs (converted to tasks). Ignored when tasks is provided."),
+        js_render: z.boolean().optional().describe("Job-level js_render for all tasks"),
+        premium_proxy: z.boolean().optional().describe("Job-level premium_proxy for all tasks"),
+        proxy_country: z
+          .string()
+          .optional()
+          .describe("Job-level ISO country code (requires premium_proxy or mode=auto)"),
+        response_type: z
+          .enum(["markdown", "plaintext", "html", "pdf"])
+          .optional()
+          .describe("Job-level response_type"),
+        zenrows_params: z
+          .record(z.union([z.string(), z.number(), z.boolean()]))
+          .optional()
+          .describe("Additional job-level zenrows_params merged with the flags above"),
+        wait: z
+          .boolean()
+          .optional()
+          .describe("If true, poll until the job reaches a terminal state before returning"),
+        wait_timeout_ms: z
+          .number()
+          .int()
+          .min(1000)
+          .max(3_600_000)
+          .optional()
+          .describe("Max wait time when wait=true (default 600000)"),
+      },
+    },
+    async (params) => {
+      type TaskIn = {
+        url: string;
+        external_id?: string;
+        metadata?: unknown;
+        zenrows_params?: Record<string, string | number | boolean>;
+      };
+      const tasksIn: TaskIn[] =
+        params.tasks && params.tasks.length > 0
+          ? params.tasks
+          : (params.urls ?? []).map((url) => ({ url }));
+      if (!tasksIn.length) {
+        return err({
+          code: "INVALID_USAGE",
+          message: "Provide tasks (preferred) or urls with at least one URL.",
+        });
+      }
+
+      const jobParams: Record<string, unknown> = { ...(params.zenrows_params ?? {}) };
+      if (params.js_render) jobParams.js_render = true;
+      if (params.premium_proxy) jobParams.premium_proxy = true;
+      if (params.proxy_country) jobParams.proxy_country = params.proxy_country.toLowerCase();
+      if (params.response_type) jobParams.response_type = params.response_type;
+
+      const body = {
+        type: "regular" as const,
+        status: "closed" as const,
+        tasks: tasksIn.map((t) => {
+          const task: {
+            url: string;
+            external_id?: string;
+            metadata?: unknown;
+            zenrows_params?: Record<string, string>;
+          } = { url: t.url };
+          if (t.external_id) task.external_id = t.external_id;
+          if (t.metadata !== undefined) task.metadata = t.metadata;
+          if (t.zenrows_params) task.zenrows_params = normalizeParams(t.zenrows_params);
+          return task;
+        }),
+        ...(Object.keys(jobParams).length
+          ? { zenrows_params: normalizeParams(jobParams) }
+          : {}),
+      };
+
+      try {
+        const job = await createJob(body, call);
+        const finished =
+          params.wait === true
+            ? await waitForJob(job.job_id, {
+                ...call,
+                pollTimeoutMs: params.wait_timeout_ms ?? 600_000,
+              })
+            : job;
+        const run = finished.latest_run ?? {};
+        return json({
+          ok: true,
+          job_id: finished.job_id,
+          status: run.status,
+          stats: run.stats,
+          job: finished,
+        });
+      } catch (e) {
+        return batchErr(e);
+      }
+    }
+  );
+
+  server.registerTool(
+    "batch_status",
+    {
+      annotations: { title: "Batch Job Status", readOnlyHint: true, destructiveHint: false },
+      description:
+        "Get status and stats for a Zenrows Batch job (latest_run.status + latest_run.stats).",
+      inputSchema: {
+        job_id: z.string().describe("Batch job id returned by batch_create"),
+      },
+    },
+    async ({ job_id }) => {
+      try {
+        const job = await getJob(job_id, call);
+        const run = job.latest_run ?? {};
+        return json({
+          ok: true,
+          job_id: job.job_id,
+          status: run.status,
+          stats: run.stats,
+          job,
+        });
+      } catch (e) {
+        return batchErr(e);
+      }
+    }
+  );
+
+  server.registerTool(
+    "batch_results",
+    {
+      annotations: { title: "Batch Job Results", readOnlyHint: true, destructiveHint: false },
+      description: `List result rows for a Batch job (cursor-paginated server-side; returns the full list).
+
+Each row may include task_id, external_id, status, and a short-lived result_url for the body.
+Download result_url soon — presigned links expire.`,
+      inputSchema: {
+        job_id: z.string().describe("Batch job id"),
+        status: z
+          .enum(["successful", "failed", "all"])
+          .optional()
+          .describe("Filter results by status (default: all)"),
+      },
+    },
+    async ({ job_id, status }) => {
+      try {
+        const results = await listResults(job_id, { ...call, status });
+        return json({ ok: true, job_id, count: results.length, results });
+      } catch (e) {
+        return batchErr(e);
+      }
+    }
+  );
+
+  server.registerTool(
+    "batch_cancel",
+    {
+      annotations: { title: "Cancel Batch Job", readOnlyHint: false, destructiveHint: true },
+      description: "Stop an in-flight Batch job run (POST /jobs/:id/stop).",
+      inputSchema: {
+        job_id: z.string().describe("Batch job id to stop"),
+      },
+    },
+    async ({ job_id }) => {
+      try {
+        const job = await stopJob(job_id, call);
+        const run = job.latest_run ?? {};
+        return json({
+          ok: true,
+          job_id: job.job_id,
+          status: run.status,
+          stats: run.stats,
+          job,
+        });
+      } catch (e) {
+        return batchErr(e);
+      }
+    }
+  );
+
+  server.registerTool(
+    "batch_wait",
+    {
+      annotations: { title: "Wait for Batch Job", readOnlyHint: true, destructiveHint: false },
+      description:
+        "Poll batch_status until the job reaches a terminal state (completed, stopped, or deleted).",
+      inputSchema: {
+        job_id: z.string().describe("Batch job id"),
+        timeout_ms: z
+          .number()
+          .int()
+          .min(1000)
+          .max(3_600_000)
+          .optional()
+          .describe("Max wait time in ms (default 600000)"),
+      },
+    },
+    async ({ job_id, timeout_ms }) => {
+      try {
+        const job = await waitForJob(job_id, { ...call, pollTimeoutMs: timeout_ms ?? 600_000 });
+        const run = job.latest_run ?? {};
+        return json({
+          ok: true,
+          job_id: job.job_id,
+          status: run.status,
+          stats: run.stats,
+          job,
+        });
+      } catch (e) {
+        return batchErr(e);
+      }
+    }
+  );
+}

--- a/src/tools/extract.ts
+++ b/src/tools/extract.ts
@@ -1,0 +1,317 @@
+import { createRequire } from "module";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
+
+const ZENROWS_API_URL = "https://api.zenrows.com/v1/";
+
+type TextContent = { type: "text"; text: string };
+
+function err(text: string): { content: TextContent[]; isError: true } {
+  return { content: [{ type: "text" as const, text }], isError: true as const };
+}
+
+function json(data: unknown): { content: TextContent[] } {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+export function zrErrorCode(body: string): string | undefined {
+  try {
+    const j = JSON.parse(body) as { code?: string; error?: string };
+    if (typeof j.code === "string") return j.code;
+    const m = typeof j.error === "string" ? j.error.match(/\((AUTH\d+)\)/) : null;
+    return m?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+function isEmptyData(data: unknown): boolean {
+  if (data === null || data === undefined) return true;
+  if (Array.isArray(data)) return data.length === 0;
+  if (typeof data === "object") return Object.keys(data as object).length === 0;
+  if (typeof data === "string") return data.trim() === "";
+  return false;
+}
+
+export type ExtractMode = "auto" | "autoparse" | "css";
+
+export type ExtractStealthOpts = {
+  css_extractor?: string;
+  js_render?: boolean;
+  premium_proxy?: boolean;
+  proxy_country?: string;
+  mode_auto?: boolean;
+  wait_for?: string;
+  wait?: number;
+};
+
+export type ExtractInput = ExtractStealthOpts & {
+  url: string;
+  mode?: ExtractMode;
+  fallback_autoparse?: boolean;
+};
+
+export type ExtractSuccess = {
+  ok: true;
+  mode: ExtractMode;
+  fellBackToAutoparse: boolean;
+  empty: boolean;
+  data: unknown;
+  html?: string;
+  raw?: string;
+};
+
+export type ExtractFailure = {
+  ok: false;
+  errorText: string;
+};
+
+export function buildExtractParams(
+  apiKey: string,
+  url: string,
+  mode: ExtractMode,
+  opts: ExtractStealthOpts
+): URLSearchParams {
+  const sp = new URLSearchParams({ apikey: apiKey, url });
+  if (mode === "auto") sp.set("extract", "auto");
+  if (mode === "autoparse") sp.set("autoparse", "true");
+  if (mode === "css" && opts.css_extractor) sp.set("css_extractor", opts.css_extractor);
+  if (opts.mode_auto) sp.set("mode", "auto");
+  if (opts.js_render) sp.set("js_render", "true");
+  if (opts.premium_proxy) sp.set("premium_proxy", "true");
+  if (opts.proxy_country) sp.set("proxy_country", opts.proxy_country.toUpperCase());
+  if (opts.wait_for) sp.set("wait_for", opts.wait_for);
+  if (opts.wait != null) sp.set("wait", String(opts.wait));
+  return sp;
+}
+
+async function callZenrows(
+  apiKey: string,
+  searchParams: URLSearchParams,
+  getClientName: () => string | undefined,
+  fetchImpl: typeof fetch
+): Promise<{ ok: boolean; status: number; body: string }> {
+  let response: Response;
+  try {
+    response = await fetchImpl(`${ZENROWS_API_URL}?${searchParams}`, {
+      headers: {
+        "User-Agent": `zenrows/mcp ${pkg.version}`,
+        ...(getClientName() ? { "x-mcp-client-name": getClientName()! } : {}),
+        "x-mcp-tool": "extract",
+      },
+    });
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      body: `Network error contacting Zenrows: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+  return { ok: response.ok, status: response.status, body: await response.text() };
+}
+
+/**
+ * Core extract logic (testable). AUTH010 on mode=auto retries once with autoparse
+ * unless fallback_autoparse is false — same behavior as the CLI extract adapter.
+ */
+export async function runExtract(
+  apiKey: string,
+  params: ExtractInput,
+  options: {
+    getClientName?: () => string | undefined;
+    fetchImpl?: typeof fetch;
+  } = {}
+): Promise<ExtractSuccess | ExtractFailure> {
+  const getClientName = options.getClientName ?? (() => undefined);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const mode: ExtractMode = params.mode ?? "auto";
+
+  if (mode === "css" && !params.css_extractor) {
+    return {
+      ok: false,
+      errorText: JSON.stringify({
+        code: "INVALID_USAGE",
+        message: "mode=css requires css_extractor JSON selector map.",
+      }),
+    };
+  }
+
+  const opts: ExtractStealthOpts = {
+    css_extractor: params.css_extractor,
+    js_render: params.js_render,
+    premium_proxy: params.premium_proxy,
+    proxy_country: params.proxy_country,
+    mode_auto: params.mode_auto,
+    wait_for: params.wait_for,
+    wait: params.wait,
+  };
+
+  let usedMode: ExtractMode = mode;
+  let result = await callZenrows(
+    apiKey,
+    buildExtractParams(apiKey, params.url, mode, opts),
+    getClientName,
+    fetchImpl
+  );
+
+  let fellBackToAutoparse = false;
+  if (
+    !result.ok &&
+    mode === "auto" &&
+    params.fallback_autoparse !== false &&
+    result.status === 402 &&
+    zrErrorCode(result.body) === "AUTH010"
+  ) {
+    usedMode = "autoparse";
+    fellBackToAutoparse = true;
+    result = await callZenrows(
+      apiKey,
+      buildExtractParams(apiKey, params.url, "autoparse", opts),
+      getClientName,
+      fetchImpl
+    );
+  }
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      errorText:
+        result.status === 0
+          ? result.body
+          : JSON.stringify({
+              code: zrErrorCode(result.body) ?? "EXTRACT_FAILED",
+              message: `Zenrows error ${result.status}`,
+              detail: result.body.slice(0, 500),
+              mode: usedMode,
+            }),
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.body);
+  } catch {
+    return {
+      ok: true,
+      mode: usedMode,
+      fellBackToAutoparse,
+      empty: true,
+      data: null,
+      raw: result.body,
+    };
+  }
+
+  let data: unknown = parsed;
+  let html: string | undefined;
+  if (usedMode === "auto" && parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const envelope = parsed as { parsed?: unknown; html?: unknown };
+    if ("parsed" in envelope) {
+      data = envelope.parsed;
+      html = typeof envelope.html === "string" ? envelope.html : undefined;
+    }
+  }
+
+  return {
+    ok: true,
+    mode: usedMode,
+    fellBackToAutoparse,
+    empty: isEmptyData(data),
+    data,
+    ...(html !== undefined ? { html } : {}),
+  };
+}
+
+export function registerExtractTool(
+  server: McpServer,
+  apiKey: string,
+  getClientName: () => string | undefined
+): void {
+  server.registerTool(
+    "extract",
+    {
+      annotations: {
+        title: "Extract Structured Data",
+        readOnlyHint: true,
+        destructiveHint: false,
+      },
+      description: `Extract structured data from a webpage via Zenrows.
+
+Prefer this over scrape when you need JSON fields (products, articles, listings)
+rather than a full page body.
+Modes:
+- auto (default): extract=auto — site-tailored Extract (open beta; currently free,
+  billing may apply later; may fall back to autoparse if the domain is not enabled)
+- autoparse: general-purpose structured JSON on any domain
+- css: css_extractor with an explicit selector map
+
+Stealth: js_render, premium_proxy, proxy_country, or mode_auto (Adaptive Stealth Mode).
+For full-page markdown/HTML/screenshots, use scrape instead.`,
+      inputSchema: {
+        url: z.string().url().describe("The webpage URL to extract from"),
+        mode: z
+          .enum(["auto", "autoparse", "css"])
+          .optional()
+          .default("auto")
+          .describe(
+            "Extraction mode: auto (extract=auto, default), autoparse, or css (requires css_extractor)"
+          ),
+        css_extractor: z
+          .string()
+          .optional()
+          .describe(
+            'Required when mode=css. JSON map of field→selector, e.g. \'{"title":"h1","price":".price"}\''
+          ),
+        js_render: z
+          .boolean()
+          .optional()
+          .describe("Enable headless JS rendering (SPAs / dynamic content)"),
+        premium_proxy: z
+          .boolean()
+          .optional()
+          .describe("Use premium residential proxies (anti-bot). Higher credit cost."),
+        proxy_country: z
+          .string()
+          .optional()
+          .describe("ISO 3166-1 alpha-2 country code. Requires premium_proxy or mode_auto."),
+        mode_auto: z
+          .boolean()
+          .optional()
+          .describe("Enable Adaptive Stealth Mode (mode=auto) for tougher sites"),
+        wait_for: z
+          .string()
+          .optional()
+          .describe("CSS selector to wait for before extracting. Requires js_render."),
+        wait: z
+          .number()
+          .int()
+          .min(0)
+          .max(30000)
+          .optional()
+          .describe("Milliseconds to wait after load. Requires js_render."),
+        fallback_autoparse: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "When mode=auto and the domain is not in Extract open beta (AUTH010), retry once with autoparse (default true)"
+          ),
+      },
+    },
+    async (params) => {
+      const outcome = await runExtract(apiKey, params, { getClientName });
+      if (!outcome.ok) return err(outcome.errorText);
+      return json({
+        ok: true,
+        mode: outcome.mode,
+        fellBackToAutoparse: outcome.fellBackToAutoparse,
+        empty: outcome.empty,
+        data: outcome.data,
+        ...(outcome.html !== undefined ? { html: outcome.html } : {}),
+        ...(outcome.raw !== undefined ? { raw: outcome.raw } : {}),
+      });
+    }
+  );
+}

--- a/tests/batch-api.test.ts
+++ b/tests/batch-api.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { BatchError, createJob, getJob } from "../src/batch-api.ts";
+
+test("createJob maps 403 problem+json to BATCH_ACCESS_DENIED", async () => {
+  const fetchImpl = (async () =>
+    new Response(JSON.stringify({ title: "Forbidden", detail: "no beta", code: "forbidden" }), {
+      status: 403,
+      headers: { "content-type": "application/problem+json" },
+    })) as typeof fetch;
+
+  await assert.rejects(
+    () => createJob({ tasks: [{ url: "https://example.com" }] }, { apiKey: "k", fetchImpl }),
+    (e: unknown) => {
+      assert.ok(e instanceof BatchError);
+      assert.equal(e.code, "BATCH_ACCESS_DENIED");
+      assert.equal(e.status, 403);
+      return true;
+    }
+  );
+});
+
+test("getJob returns parsed job on 200", async () => {
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    assert.match(String(input), /\/jobs\/job-1$/);
+    return new Response(
+      JSON.stringify({
+        job_id: "job-1",
+        latest_run: { status: "completed", stats: { total: 1, completed: 1, successful: 1, failed: 0 } },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  }) as typeof fetch;
+
+  const job = await getJob("job-1", { apiKey: "k", fetchImpl });
+  assert.equal(job.job_id, "job-1");
+  assert.equal(job.latest_run.status, "completed");
+});
+
+test("createJob maps 401 to AUTH_INVALID", async () => {
+  const fetchImpl = (async () =>
+    new Response(JSON.stringify({ detail: "bad key" }), { status: 401 })) as typeof fetch;
+  await assert.rejects(
+    () => createJob({ tasks: [{ url: "https://example.com" }] }, { apiKey: "bad", fetchImpl }),
+    (e: unknown) => e instanceof BatchError && e.code === "AUTH_INVALID"
+  );
+});

--- a/tests/ensure-key.test.ts
+++ b/tests/ensure-key.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+import {
+  AuthError,
+  AUTO_SIGNUP_ENV,
+  ENV_KEY,
+  ZENROWS_HOME_ENV,
+  _resetDiscoveryCache,
+  ensureApiKey,
+  resolveApiKey,
+  signupAgent,
+} from "../src/auth/ensure-key.ts";
+
+let home: string;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "zr-mcp-auth-"));
+  for (const k of [ENV_KEY, AUTO_SIGNUP_ENV, ZENROWS_HOME_ENV, "ZENROWS_AGENT_SIGNUP_URL"]) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env[ZENROWS_HOME_ENV] = home;
+  _resetDiscoveryCache();
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  _resetDiscoveryCache();
+  rmSync(home, { recursive: true, force: true });
+});
+
+test("resolveApiKey prefers env over secrets file", async () => {
+  process.env[ENV_KEY] = "env-key";
+  const r = resolveApiKey();
+  assert.equal(r.source, "env");
+  assert.equal(r.key, "env-key");
+});
+
+test("ensureApiKey throws when auto-signup disabled and no key", async () => {
+  process.env[AUTO_SIGNUP_ENV] = "false";
+  await assert.rejects(() => ensureApiKey(), (e: unknown) => {
+    assert.ok(e instanceof AuthError);
+    assert.equal(e.code, "AUTH_MISSING");
+    return true;
+  });
+});
+
+test("ensureApiKey provisions via signup and persists secrets + account", async () => {
+  const fetchImpl = (async () =>
+    new Response(
+      JSON.stringify({
+        apiKey: "prov-key",
+        accountId: "acct-1",
+        claimUrl: "https://app.zenrows.com/claim/tok",
+      }),
+      { status: 201, headers: { "content-type": "application/json" } }
+    )) as typeof fetch;
+
+  process.env.ZENROWS_AGENT_SIGNUP_URL = "https://example.test/signup";
+  const result = await ensureApiKey({ fetchImpl });
+  assert.equal(result.apiKey, "prov-key");
+  assert.equal(result.provisioned?.claimUrl, "https://app.zenrows.com/claim/tok");
+
+  const secrets = JSON.parse(readFileSync(join(home, ".zenrows", "secrets.json"), "utf8"));
+  const account = JSON.parse(readFileSync(join(home, ".zenrows", "account.json"), "utf8"));
+  assert.equal(secrets.apiKey, "prov-key");
+  assert.equal(account.accountId, "acct-1");
+  assert.equal(account.unclaimed, true);
+
+  // second call uses stored key without hitting signup again
+  let calls = 0;
+  const fetchOnce = (async () => {
+    calls++;
+    throw new Error("should not fetch");
+  }) as typeof fetch;
+  const again = await ensureApiKey({ fetchImpl: fetchOnce });
+  assert.equal(again.apiKey, "prov-key");
+  assert.equal(calls, 0);
+});
+
+test("signupAgent maps 429 to SIGNUP_RATE_LIMITED", async () => {
+  process.env.ZENROWS_AGENT_SIGNUP_URL = "https://example.test/signup";
+  const fetchImpl = (async () =>
+    new Response("slow down", { status: 429 })) as typeof fetch;
+  await assert.rejects(() => signupAgent({ fetchImpl }), (e: unknown) => {
+    assert.ok(e instanceof AuthError);
+    assert.equal(e.code, "SIGNUP_RATE_LIMITED");
+    return true;
+  });
+});

--- a/tests/extract.test.ts
+++ b/tests/extract.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildExtractParams,
+  runExtract,
+  zrErrorCode,
+} from "../src/tools/extract.ts";
+
+const AUTH010 = JSON.stringify({
+  code: "AUTH010",
+  title: "Feature is not included in plan (AUTH010)",
+});
+
+const AUTH004 = JSON.stringify({
+  code: "AUTH004",
+  title: "Concurrency limit reached (AUTH004)",
+});
+
+test("buildExtractParams sets extract=auto for mode auto", () => {
+  const sp = buildExtractParams("k", "https://example.com", "auto", {});
+  assert.equal(sp.get("extract"), "auto");
+  assert.equal(sp.get("autoparse"), null);
+});
+
+test("buildExtractParams sets autoparse for mode autoparse", () => {
+  const sp = buildExtractParams("k", "https://example.com", "autoparse", {});
+  assert.equal(sp.get("autoparse"), "true");
+  assert.equal(sp.get("extract"), null);
+});
+
+test("zrErrorCode reads code field and AUTH from error string", () => {
+  assert.equal(zrErrorCode(AUTH010), "AUTH010");
+  assert.equal(zrErrorCode(JSON.stringify({ error: "nope (AUTH004)" })), "AUTH004");
+});
+
+test("runExtract falls back to autoparse on AUTH010 for mode=auto", async () => {
+  const calls: string[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    calls.push(url);
+    if (url.includes("extract=auto")) {
+      return new Response(AUTH010, { status: 402, headers: { "content-type": "application/json" } });
+    }
+    return new Response(JSON.stringify({ title: "fallback" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  const outcome = await runExtract(
+    "testkey",
+    { url: "https://example.com" },
+    { fetchImpl }
+  );
+
+  assert.equal(outcome.ok, true);
+  if (!outcome.ok) return;
+  assert.equal(outcome.mode, "autoparse");
+  assert.equal(outcome.fellBackToAutoparse, true);
+  assert.deepEqual(outcome.data, { title: "fallback" });
+  assert.equal(calls.length, 2);
+  assert.match(calls[0]!, /extract=auto/);
+  assert.match(calls[1]!, /autoparse=true/);
+  assert.doesNotMatch(calls[1]!, /extract=auto/);
+});
+
+test("runExtract does not fall back when fallback_autoparse is false", async () => {
+  let calls = 0;
+  const fetchImpl = (async () => {
+    calls += 1;
+    return new Response(AUTH010, { status: 402, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  const outcome = await runExtract(
+    "testkey",
+    { url: "https://example.com", fallback_autoparse: false },
+    { fetchImpl }
+  );
+
+  assert.equal(outcome.ok, false);
+  if (outcome.ok) return;
+  assert.equal(calls, 1);
+  const body = JSON.parse(outcome.errorText) as { code: string; mode: string };
+  assert.equal(body.code, "AUTH010");
+  assert.equal(body.mode, "auto");
+});
+
+test("runExtract does not fall back on AUTH004", async () => {
+  let calls = 0;
+  const fetchImpl = (async () => {
+    calls += 1;
+    return new Response(AUTH004, { status: 402, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+
+  const outcome = await runExtract("testkey", { url: "https://example.com" }, { fetchImpl });
+  assert.equal(outcome.ok, false);
+  assert.equal(calls, 1);
+  if (outcome.ok) return;
+  assert.equal(JSON.parse(outcome.errorText).code, "AUTH004");
+});
+
+test("runExtract surfaces autoparse failure after AUTH010 fallback", async () => {
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("extract=auto")) {
+      return new Response(AUTH010, { status: 402, headers: { "content-type": "application/json" } });
+    }
+    return new Response("upstream boom", { status: 500, headers: { "content-type": "text/plain" } });
+  }) as typeof fetch;
+
+  const outcome = await runExtract("testkey", { url: "https://example.com" }, { fetchImpl });
+  assert.equal(outcome.ok, false);
+  if (outcome.ok) return;
+  const body = JSON.parse(outcome.errorText) as { code: string; mode: string };
+  assert.equal(body.code, "EXTRACT_FAILED");
+  assert.equal(body.mode, "autoparse");
+});
+
+test("runExtract unwraps extract=auto {parsed,html} envelope", async () => {
+  const fetchImpl = (async () =>
+    new Response(JSON.stringify({ parsed: { title: "T" }, html: "<h1>T</h1>" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+
+  const outcome = await runExtract("testkey", { url: "https://example.com" }, { fetchImpl });
+  assert.equal(outcome.ok, true);
+  if (!outcome.ok) return;
+  assert.equal(outcome.mode, "auto");
+  assert.equal(outcome.fellBackToAutoparse, false);
+  assert.deepEqual(outcome.data, { title: "T" });
+  assert.equal(outcome.html, "<h1>T</h1>");
+});
+
+test("runExtract mode=css requires css_extractor", async () => {
+  const outcome = await runExtract("k", { url: "https://example.com", mode: "css" });
+  assert.equal(outcome.ok, false);
+  if (outcome.ok) return;
+  assert.equal(JSON.parse(outcome.errorText).code, "INVALID_USAGE");
+});


### PR DESCRIPTION
Expose first-class extract and Batch API tools (create/status/results/ cancel/wait). Stdio provisions via /api/agent/signup into ~/.zenrows when no key is set; remote HTTP stays Bearer/OAuth-only.