### PR TITLE
Sync + automate MCP Registry publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
+      - run: npm run check:server-json
       - run: npm run typecheck
       - run: npm run lint
       - run: npm test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,23 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # Catch-up / metadata-only republish without cutting a new npm version.
+  workflow_dispatch:
+    inputs:
+      publish_npm:
+        description: "Also publish to npm (default: registry only)"
+        type: boolean
+        default: false
+      publish_ghcr:
+        description: "Also build/push GHCR + deploy (default: registry only)"
+        type: boolean
+        default: false
 
 jobs:
   # Hosted MCP (Lambda) only needs GHCR. Don't block it on npm registry auth.
   publish-ghcr:
     name: GHCR + deploy
+    if: github.event_name == 'push' || inputs.publish_ghcr
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,14 +46,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve image tag
+        id: meta
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push to GHCR
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           docker build --platform linux/arm64 \
-            -t ghcr.io/${OWNER}/zenrows-mcp:${{ github.ref_name }} \
+            -t ghcr.io/${OWNER}/zenrows-mcp:${{ steps.meta.outputs.tag }} \
             -t ghcr.io/${OWNER}/zenrows-mcp:latest \
             .
-          docker push ghcr.io/${OWNER}/zenrows-mcp:${{ github.ref_name }}
+          docker push ghcr.io/${OWNER}/zenrows-mcp:${{ steps.meta.outputs.tag }}
           docker push ghcr.io/${OWNER}/zenrows-mcp:latest
 
       - name: Create deploy token
@@ -58,13 +79,14 @@ jobs:
           gh api repos/ZenRows/zenrows-mcp-deploy/dispatches \
             --method POST \
             --input - <<EOF
-          {"event_type":"deploy","client_payload":{"tag":"${{ github.ref_name }}"}}
+          {"event_type":"deploy","client_payload":{"tag":"${{ steps.meta.outputs.tag }}"}}
           EOF
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   publish-npm:
     name: npm
+    if: github.event_name == 'push' || inputs.publish_npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -81,6 +103,7 @@ jobs:
           cache: "npm"
 
       - run: npm ci
+      - run: npm run check:server-json
       - run: npm test
       - run: npm run build
 
@@ -88,3 +111,51 @@ jobs:
       # configured on https://www.npmjs.com/package/@zenrows/mcp (Settings).
       # Provenance is automatic with trusted publishing.
       - run: npm publish --access public
+
+  # Official MCP Registry (registry.modelcontextprotocol.io). Independent of npm
+  # publish so metadata can be fixed without cutting a new package version.
+  publish-mcp-registry:
+    name: MCP Registry
+    # After npm on tag pushes (package must exist for ownership checks). On
+    # workflow_dispatch, npm is optional — assumed already published.
+    needs: [publish-npm]
+    if: |
+      always() && !cancelled() && (
+        (github.event_name == 'push' && needs.publish-npm.result == 'success') ||
+        (github.event_name == 'workflow_dispatch' && (inputs.publish_npm == false || needs.publish-npm.result == 'success'))
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # OIDC for mcp-publisher login github-oidc
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Sync server.json version from package.json / tag
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            export VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          npm run sync:server-json
+          npm run check:server-json
+          cat server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json
+        run: ./mcp-publisher publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zenrows/mcp",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zenrows/mcp",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenrows/mcp",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Zenrows MCP server — Fetch, Extract, Batch, and Browser Sessions for AI coding assistants",
   "type": "module",
   "bin": {
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "tsc && chmod +x dist/index.js",
+    "check:server-json": "node scripts/sync-server-json-version.mjs --check",
     "clean": "rm -rf dist",
     "dev": "node --env-file=.env --import tsx src/index.ts",
     "dev:http": "node --env-file=.env --import tsx src/http.ts",
@@ -20,8 +21,9 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run clean && npm run build && npm run typecheck && npm run lint && npm test",
+    "prepublishOnly": "npm run clean && npm run build && npm run typecheck && npm run lint && npm test && npm run check:server-json",
     "publish-beta": "npm publish --tag beta",
+    "sync:server-json": "node scripts/sync-server-json-version.mjs",
     "test": "node --import tsx --test tests/*.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/sync-server-json-version.mjs
+++ b/scripts/sync-server-json-version.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Keep server.json version fields aligned with package.json (or an explicit VERSION).
+ *
+ * Usage:
+ *   node scripts/sync-server-json-version.mjs           # from package.json
+ *   VERSION=2.2.0 node scripts/sync-server-json-version.mjs
+ *   node scripts/sync-server-json-version.mjs --check   # exit 1 on drift
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkgPath = join(root, "package.json");
+const serverPath = join(root, "server.json");
+
+const checkOnly = process.argv.includes("--check");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+const version = process.env.VERSION?.replace(/^v/, "") || pkg.version;
+
+if (!/^\d+\.\d+\.\d+/.test(version)) {
+  console.error(`Invalid version: ${version}`);
+  process.exit(1);
+}
+
+const server = JSON.parse(readFileSync(serverPath, "utf8"));
+const npmPkg = server.packages?.find((p) => p.registryType === "npm");
+
+const drifts = [];
+if (server.version !== version) drifts.push(`server.version=${server.version}`);
+if (!npmPkg) drifts.push("missing npm package entry");
+else if (npmPkg.version !== version) drifts.push(`packages[npm].version=${npmPkg.version}`);
+
+if (checkOnly) {
+  if (drifts.length) {
+    console.error(
+      `server.json out of sync with ${version} (package.json${process.env.VERSION ? " / VERSION" : ""}): ${drifts.join(", ")}`,
+    );
+    process.exit(1);
+  }
+  console.log(`server.json OK @ ${version}`);
+  process.exit(0);
+}
+
+server.version = version;
+if (npmPkg) npmPkg.version = version;
+
+// Keep package description as the catalog blurb when present.
+if (typeof pkg.description === "string" && pkg.description.trim()) {
+  server.description = pkg.description;
+}
+
+writeFileSync(serverPath, `${JSON.stringify(server, null, 2)}\n`);
+console.log(`Synced server.json → ${version}`);

--- a/server.json
+++ b/server.json
@@ -1,31 +1,41 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.ZenRows/zenrows-mcp",
-  "description": "Zenrows MCP server — Fetch and Browser Sessions for AI coding assistants",
-  "author": {
-    "name": "Zenrows",
-    "url": "https://github.com/ZenRows"
-  },
+  "description": "Zenrows MCP server — Fetch, Extract, Batch, and Browser Sessions for AI coding assistants",
   "repository": {
     "url": "https://github.com/ZenRows/zenrows-mcp",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "2.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@zenrows/mcp",
-      "version": "1.0.0",
+      "version": "2.2.0",
       "transport": {
         "type": "stdio"
       },
       "environmentVariables": [
         {
-          "description": "Your Zenrows API key from https://app.zenrows.com/account/settings",
-          "isRequired": true,
+          "description": "Optional ZenRows API key (https://app.zenrows.com/account/settings). If unset, stdio auto-provisions a Free account unless ZENROWS_AUTO_SIGNUP=false.",
+          "isRequired": false,
           "format": "string",
           "isSecret": true,
           "name": "ZENROWS_API_KEY"
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.zenrows.com/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer <ZENROWS_API_KEY>, or use OAuth in clients that support it. Remote MCP does not auto-create accounts.",
+          "isRequired": false,
+          "isSecret": true
         }
       ]
     }

--- a/tests/sync-server-json-version.test.ts
+++ b/tests/sync-server-json-version.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(
+  new URL("../scripts/sync-server-json-version.mjs", import.meta.url),
+);
+
+function fixture(version) {
+  const dir = mkdtempSync(join(tmpdir(), "server-json-sync-"));
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({
+      name: "@zenrows/mcp",
+      version,
+      description: `desc-${version}`,
+    }),
+  );
+  mkdirSync(join(dir, "scripts"), { recursive: true });
+  writeFileSync(join(dir, "scripts", "sync-server-json-version.mjs"), readFileSync(script));
+  writeFileSync(
+    join(dir, "server.json"),
+    JSON.stringify({
+      name: "io.github.ZenRows/zenrows-mcp",
+      description: "old",
+      version: "0.0.0",
+      packages: [
+        {
+          registryType: "npm",
+          identifier: "@zenrows/mcp",
+          version: "0.0.0",
+          transport: { type: "stdio" },
+        },
+      ],
+    }),
+  );
+  return dir;
+}
+
+describe("sync-server-json-version", () => {
+  it("syncs version + description from package.json", () => {
+    const dir = fixture("9.9.9");
+    try {
+      const r = spawnSync(process.execPath, ["scripts/sync-server-json-version.mjs"], {
+        cwd: dir,
+        encoding: "utf8",
+      });
+      assert.equal(r.status, 0, r.stderr);
+      const server = JSON.parse(readFileSync(join(dir, "server.json"), "utf8"));
+      assert.equal(server.version, "9.9.9");
+      assert.equal(server.packages[0].version, "9.9.9");
+      assert.equal(server.description, "desc-9.9.9");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--check fails on drift", () => {
+    const dir = fixture("1.2.3");
+    try {
+      const r = spawnSync(
+        process.execPath,
+        ["scripts/sync-server-json-version.mjs", "--check"],
+        { cwd: dir, encoding: "utf8" },
+      );
+      assert.notEqual(r.status, 0);
+      assert.match(r.stderr, /out of sync/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Bump `server.json` to **2.2.0** (matches npm), refresh description, mark API key optional, add remote `https://mcp.zenrows.com/mcp`
- Add `scripts/sync-server-json-version.mjs` + CI/`prepublishOnly` `--check` so package vs catalog drift fails the build
- Extend Publish workflow: `mcp-publisher` via GitHub OIDC after npm on `v*` tags; `workflow_dispatch` for registry-only catch-up republishes (this 1.0.0 → 2.2.0 fix)

## Test plan
- [x] `npm test` (incl. sync script tests)
- [x] `npm run check:server-json`
- [ ] Merge → Actions → **Publish** → Run workflow (`workflow_dispatch`, npm/ghcr off) → confirm registry shows `2.2.0`
- [ ] Next `v*` tag should publish npm + registry together without manual `server.json` edits


Made with [Cursor](https://cursor.com)