### PR TITLE
Let an agent see its allowance, and stop skipping the nudge on AUTH004

### DIFF
--- a/src/auth/claim-hint.ts
+++ b/src/auth/claim-hint.ts
@@ -5,8 +5,17 @@ import { readAccount } from "./ensure-key.js";
 
 const CLAIM_NUDGE = "Claim your Free account to keep usage and upgrade: ";
 
-/** AUTH004 is concurrency, not trial credits — don't nudge claim for it. */
-const SKIP_CODES = new Set(["AUTH004"]);
+/**
+ * Codes that are not an allowance problem, so a claim nudge would be noise.
+ *
+ * AUTH006 is the concurrency limit. AUTH004 used to be listed here on the belief that it
+ * was concurrency too — it is not. AUTH004 is "Usage Exceeded": the allowance itself is
+ * spent (docs `api-error-codes#AUTH004`; gateway logs carry `err: "usage exceeded"`,
+ * `msg: "user allowance failure"`). Skipping it suppressed the nudge at the one moment it
+ * is worth the most — an unclaimed Free agent that has just run through its allowance and
+ * would otherwise lose the account along with its usage history.
+ */
+const SKIP_CODES = new Set(["AUTH006"]);
 
 function extractCode(body?: string, code?: string): string | undefined {
   if (code && typeof code === "string") return code;
@@ -22,12 +31,14 @@ function extractCode(body?: string, code?: string): string | undefined {
   }
 }
 
-export function isQuotaOrPlanError(opts: {
-  status?: number;
-  body?: string;
-  code?: string;
-  message?: string;
-} = {}): boolean {
+export function isQuotaOrPlanError(
+  opts: {
+    status?: number;
+    body?: string;
+    code?: string;
+    message?: string;
+  } = {}
+): boolean {
   const code = extractCode(opts.body, opts.code);
   if (code && SKIP_CODES.has(code)) return false;
 

--- a/src/auth/claim-hint.ts
+++ b/src/auth/claim-hint.ts
@@ -8,7 +8,11 @@ const CLAIM_NUDGE = "Claim your Free account to keep usage and upgrade: ";
 /**
  * Codes that are not an allowance problem, so a claim nudge would be noise.
  *
- * AUTH006 is the concurrency limit. AUTH004 used to be listed here on the belief that it
+ * AUTH006 is the concurrency limit, and is belt-and-braces: it comes back as 429, so it
+ * would not reach the 402 branch below in the first place. It is listed to keep the
+ * intent legible rather than because anything depends on it.
+ *
+ * AUTH004 used to be listed here on the belief that it
  * was concurrency too — it is not. AUTH004 is "Usage Exceeded": the allowance itself is
  * spent (docs `api-error-codes#AUTH004`; gateway logs carry `err: "usage exceeded"`,
  * `msg: "user allowance failure"`). Skipping it suppressed the nudge at the one moment it

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { appendClaimHint } from "./auth/claim-hint.js";
 import { getZenrowsDir, readAccount } from "./auth/ensure-key.js";
+import { registerAccountTools } from "./tools/account.js";
 import { registerBatchTools } from "./tools/batch.js";
 import { registerBrowserTools } from "./tools/browser.js";
 import { registerExtractTool } from "./tools/extract.js";
@@ -15,7 +16,8 @@ const ZENROWS_API_URL = "https://api.zenrows.com/v1/";
 const DEFAULT_JS_RENDER = process.env.ZENROWS_JS_RENDER === "true";
 const DEFAULT_PREMIUM_PROXY = process.env.ZENROWS_PREMIUM_PROXY === "true";
 const DEFAULT_RESPONSE_TYPE =
-  (process.env.ZENROWS_RESPONSE_TYPE as "markdown" | "plaintext" | "html" | undefined) ?? "markdown";
+  (process.env.ZENROWS_RESPONSE_TYPE as "markdown" | "plaintext" | "html" | undefined) ??
+  "markdown";
 
 export function createServer(apiKey: string, clientName?: string): McpServer {
   const server = new McpServer({
@@ -349,6 +351,7 @@ Examples:
 
   registerExtractTool(server, apiKey, getClientName);
   registerBatchTools(server, apiKey);
+  registerAccountTools(server, apiKey);
 
   const BROWSER_URL = process.env.ZENROWS_BROWSER_URL ?? "https://mcp.zenrows.com";
   registerBrowserTools(server, apiKey, BROWSER_URL, getClientName);

--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -106,7 +106,11 @@ Credit costs per request: 1 basic, 5 js_render, 10 premium_proxy, 25 both. On a 
 plan a few hundred protected requests can exhaust a month, so check before fanning out.
 
 AUTH004 ("usage exceeded") means this allowance is spent. It renews at the end of the
-billing period — it is not a permanent block and not a request to buy anything.
+billing period, so it is not a permanent block: never retry-loop against it. If the
+human does not want to wait for the renewal, relay the way to continue now: add a
+credit pack at https://app.zenrows.com/billing?topup=open (opens the purchase
+directly) or upgrade at https://app.zenrows.com/plans. Prices are per plan; quote them
+only from this tool's response, never from memory.
 AUTH006 is the concurrency limit, which is a different thing entirely.`,
       inputSchema: {},
     },

--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -42,7 +42,51 @@ function json(data: unknown): { content: TextContent[] } {
   return { content: [{ type: "text", text: JSON.stringify(data) }] };
 }
 
-export function registerAccountTools(server: McpServer, apiKey: string): void {
+export type AccountOpts = { fetchImpl?: typeof fetch };
+
+/**
+ * Read the plan's usage. Split out from the handler so it can be exercised without an
+ * MCP server or a live account — the endpoint is the one thing here we cannot try
+ * against production from a test.
+ */
+export async function runAccountUsage(apiKey: string, opts: AccountOpts = {}) {
+  const doFetch = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch(SUBSCRIPTION_DETAILS_URL, {
+      headers: {
+        "X-API-Key": apiKey,
+        "User-Agent": `zenrows-mcp/${pkg.version}`,
+      },
+    });
+  } catch (e) {
+    return err(`Could not reach the Zenrows subscription endpoint: ${(e as Error).message}`);
+  }
+
+  const body = await res.text();
+
+  if (!res.ok) {
+    return err(`Zenrows returned ${res.status} for the subscription details endpoint.\n${body}`, {
+      status: res.status,
+      body,
+    });
+  }
+
+  // Passed through verbatim. The response shape is not part of any documented contract,
+  // so reshaping it here would mean inventing field names that could drift away from
+  // what the API actually sends.
+  try {
+    return json(JSON.parse(body));
+  } catch {
+    return json({ raw: body });
+  }
+}
+
+export function registerAccountTools(
+  server: McpServer,
+  apiKey: string,
+  opts: AccountOpts = {}
+): void {
   server.registerTool(
     "account_usage",
     {
@@ -66,36 +110,6 @@ billing period — it is not a permanent block and not a request to buy anything
 AUTH006 is the concurrency limit, which is a different thing entirely.`,
       inputSchema: {},
     },
-    async () => {
-      let res: Response;
-      try {
-        res = await fetch(SUBSCRIPTION_DETAILS_URL, {
-          headers: {
-            "X-API-Key": apiKey,
-            "User-Agent": `zenrows-mcp/${pkg.version}`,
-          },
-        });
-      } catch (e) {
-        return err(`Could not reach the Zenrows subscription endpoint: ${(e as Error).message}`);
-      }
-
-      const body = await res.text();
-
-      if (!res.ok) {
-        return err(
-          `Zenrows returned ${res.status} for the subscription details endpoint.\n${body}`,
-          { status: res.status, body }
-        );
-      }
-
-      // Passed through verbatim. The response shape is not part of any documented
-      // contract, so reshaping it here would mean inventing field names that could drift
-      // away from what the API actually sends.
-      try {
-        return json(JSON.parse(body));
-      } catch {
-        return json({ raw: body });
-      }
-    }
+    async () => runAccountUsage(apiKey, opts)
   );
 }

--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -1,0 +1,101 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createRequire } from "module";
+import { appendClaimHint } from "../auth/claim-hint.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
+
+/**
+ * Let an agent read its own allowance before it runs out of it.
+ *
+ * Until now nothing on this server could answer "how many credits do I have left?".
+ * Responses carry `X-Request-Cost` and `X-Request-Credits` — what a call *cost*, after
+ * the fact — but no counterpart to `Concurrency-Limit` / `Concurrency-Remaining`, so an
+ * agent could total its own spend and still not know the ceiling. It found out by
+ * hitting a 402 telling it to buy a subscription (ACT-1581, ACT-1577).
+ *
+ * `/v1/subscriptions/self/details` has always had the answer. It does not count against
+ * concurrency, which is what makes it safe to call before a batch or on a retry.
+ */
+
+const SUBSCRIPTION_DETAILS_URL = "https://api.zenrows.com/v1/subscriptions/self/details";
+
+type TextContent = { type: "text"; text: string };
+
+function err(text: string, opts: { status?: number; body?: string } = {}) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: appendClaimHint(text, {
+          status: opts.status,
+          body: opts.body ?? text,
+          message: text,
+        }),
+      },
+    ],
+    isError: true as const,
+  };
+}
+
+function json(data: unknown): { content: TextContent[] } {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+export function registerAccountTools(server: McpServer, apiKey: string): void {
+  server.registerTool(
+    "account_usage",
+    {
+      annotations: {
+        title: "Check Credit Usage",
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      description: `Read the current plan's credit allowance and how much of it is spent.
+
+Call this BEFORE a large batch, and after any 402 / AUTH004, to find out whether the
+account is out of credits and when the allowance renews. It is free and does not consume
+a concurrency slot, so it is safe to poll between runs.
+
+Credit costs per request: 1 basic, 5 js_render, 10 premium_proxy, 25 both. On a small
+plan a few hundred protected requests can exhaust a month, so check before fanning out.
+
+AUTH004 ("usage exceeded") means this allowance is spent. It renews at the end of the
+billing period — it is not a permanent block and not a request to buy anything.
+AUTH006 is the concurrency limit, which is a different thing entirely.`,
+      inputSchema: {},
+    },
+    async () => {
+      let res: Response;
+      try {
+        res = await fetch(SUBSCRIPTION_DETAILS_URL, {
+          headers: {
+            "X-API-Key": apiKey,
+            "User-Agent": `zenrows-mcp/${pkg.version}`,
+          },
+        });
+      } catch (e) {
+        return err(`Could not reach the Zenrows subscription endpoint: ${(e as Error).message}`);
+      }
+
+      const body = await res.text();
+
+      if (!res.ok) {
+        return err(
+          `Zenrows returned ${res.status} for the subscription details endpoint.\n${body}`,
+          { status: res.status, body }
+        );
+      }
+
+      // Passed through verbatim. The response shape is not part of any documented
+      // contract, so reshaping it here would mean inventing field names that could drift
+      // away from what the API actually sends.
+      try {
+        return json(JSON.parse(body));
+      } catch {
+        return json({ raw: body });
+      }
+    }
+  );
+}

--- a/tests/account.test.ts
+++ b/tests/account.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+import { ZENROWS_HOME_ENV } from "../src/auth/ensure-key.ts";
+import { registerAccountTools, runAccountUsage } from "../src/tools/account.ts";
+
+/**
+ * The endpoint itself cannot be exercised from here, so what these tests pin is
+ * everything around it: that the request is addressed and authenticated the way the API
+ * expects, and that a failure surfaces as an error an agent can act on rather than a
+ * silent empty object.
+ */
+
+let home: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "zr-mcp-account-"));
+  savedHome = process.env[ZENROWS_HOME_ENV];
+  process.env[ZENROWS_HOME_ENV] = home;
+  mkdirSync(join(home, ".zenrows"), { mode: 0o700 });
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env[ZENROWS_HOME_ENV];
+  else process.env[ZENROWS_HOME_ENV] = savedHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function writeUnclaimed(claimUrl = "https://app.zenrows.com/claim/tok"): void {
+  writeFileSync(
+    join(home, ".zenrows", "account.json"),
+    JSON.stringify({
+      accountId: "acct-1",
+      unclaimed: true,
+      claimUrl,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }) + "\n",
+    { mode: 0o600 }
+  );
+}
+
+function textOf(res: unknown): string {
+  return (res as { content: Array<{ text: string }> }).content[0].text;
+}
+
+function isError(res: unknown): boolean {
+  return (res as { isError?: boolean }).isError === true;
+}
+
+const OK_BODY = JSON.stringify({
+  status: "TRIALING",
+  usage: 4.755,
+  usage_percent: 95.1,
+  period_ends_at: "2026-09-14T00:00:00Z",
+  plan: { name: "trial", price: 5 },
+});
+
+test("calls the documented endpoint with the header auth it expects", async () => {
+  let seenUrl: string | undefined;
+  let seenHeaders: Record<string, string> = {};
+
+  await runAccountUsage("secret-key", {
+    fetchImpl: (async (url: string, init?: RequestInit) => {
+      seenUrl = String(url);
+      seenHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return new Response(OK_BODY, { status: 200 });
+    }) as unknown as typeof fetch,
+  });
+
+  // The scraper authenticates with an `apikey` query param; this endpoint does not.
+  assert.equal(seenUrl, "https://api.zenrows.com/v1/subscriptions/self/details");
+  assert.equal(seenHeaders["X-API-Key"], "secret-key");
+  assert.match(seenHeaders["User-Agent"] ?? "", /^zenrows-mcp\//);
+});
+
+test("passes the response through unchanged rather than reshaping it", async () => {
+  const res = await runAccountUsage("k", {
+    fetchImpl: (async () => new Response(OK_BODY, { status: 200 })) as unknown as typeof fetch,
+  });
+
+  assert.equal(isError(res), false);
+  // Field names are not a documented contract, so the tool must not rename or drop any.
+  assert.deepEqual(JSON.parse(textOf(res)), JSON.parse(OK_BODY));
+});
+
+test("a non-JSON body is returned as raw text, not swallowed", async () => {
+  const res = await runAccountUsage("k", {
+    fetchImpl: (async () =>
+      new Response("<html>maintenance</html>", { status: 200 })) as unknown as typeof fetch,
+  });
+
+  assert.deepEqual(JSON.parse(textOf(res)), { raw: "<html>maintenance</html>" });
+});
+
+test("surfaces a failed status as an error, with the body kept for diagnosis", async () => {
+  const res = await runAccountUsage("k", {
+    fetchImpl: (async () =>
+      new Response('{"code":"AUTH003"}', { status: 401 })) as unknown as typeof fetch,
+  });
+
+  assert.equal(isError(res), true);
+  assert.match(textOf(res), /401/);
+  assert.match(textOf(res), /AUTH003/);
+});
+
+test("a network failure reports the cause instead of looking like an empty account", async () => {
+  const res = await runAccountUsage("k", {
+    fetchImpl: (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch,
+  });
+
+  assert.equal(isError(res), true);
+  assert.match(textOf(res), /ECONNREFUSED/);
+});
+
+test("an unclaimed agent hitting the credit wall here still gets the claim nudge", async () => {
+  // The same 402 that AUTH004 returns on a scrape can come back from this endpoint.
+  // An unclaimed Free account is exactly who needs telling before they walk away.
+  writeUnclaimed("https://app.zenrows.com/claim/abc");
+
+  const res = await runAccountUsage("k", {
+    fetchImpl: (async () =>
+      new Response('{"code":"AUTH004","title":"Usage exceeded (AUTH004)"}', {
+        status: 402,
+      })) as unknown as typeof fetch,
+  });
+
+  assert.equal(isError(res), true);
+  assert.match(textOf(res), /Claim your Free account/);
+  assert.match(textOf(res), /https:\/\/app\.zenrows\.com\/claim\/abc/);
+});
+
+test("registers exactly one read-only tool named account_usage", () => {
+  const registered: Array<{ name: string; config: { annotations?: Record<string, unknown> } }> = [];
+  const server = {
+    registerTool: (name: string, config: { annotations?: Record<string, unknown> }) => {
+      registered.push({ name, config });
+    },
+  };
+
+  registerAccountTools(server as never, "k");
+
+  assert.equal(registered.length, 1);
+  assert.equal(registered[0].name, "account_usage");
+  assert.equal(registered[0].config.annotations?.readOnlyHint, true);
+});

--- a/tests/claim-hint.test.ts
+++ b/tests/claim-hint.test.ts
@@ -4,10 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, test } from "node:test";
 import { ZENROWS_HOME_ENV } from "../src/auth/ensure-key.ts";
-import {
-  appendClaimHint,
-  isQuotaOrPlanError,
-} from "../src/auth/claim-hint.ts";
+import { appendClaimHint, isQuotaOrPlanError } from "../src/auth/claim-hint.ts";
 
 let home: string;
 let savedHome: string | undefined;
@@ -61,18 +58,43 @@ test("isQuotaOrPlanError detects 402 and credit/quota signals", () => {
     }),
     false
   );
+  // AUTH004 is "Usage Exceeded" — the allowance itself is spent — not concurrency.
+  // It was previously skipped on the opposite belief, which silenced the claim nudge at
+  // the one moment an unclaimed Free agent most needs it.
   assert.equal(
     isQuotaOrPlanError({
       status: 402,
-      body: JSON.stringify({ code: "AUTH004", title: "Concurrency limit reached (AUTH004)" }),
+      body: JSON.stringify({ code: "AUTH004", title: "Usage exceeded (AUTH004)" }),
+    }),
+    true
+  );
+  // AUTH006 is the concurrency limit, and is genuinely not an allowance problem.
+  assert.equal(
+    isQuotaOrPlanError({
+      status: 402,
+      body: JSON.stringify({ code: "AUTH006", title: "Concurrency limit reached (AUTH006)" }),
     }),
     false
   );
 });
 
+test("appendClaimHint nudges an unclaimed agent that has spent its allowance", () => {
+  writeUnclaimed("https://app.zenrows.com/claim/xyz");
+  const msg = 'Zenrows error 402: {"code":"AUTH004","title":"Usage exceeded (AUTH004)"}';
+  const out = appendClaimHint(msg, { status: 402, body: msg });
+  assert.match(out, /Claim your Free account/);
+  assert.match(out, /https:\/\/app\.zenrows\.com\/claim\/xyz/);
+});
+
+test("appendClaimHint stays quiet on a concurrency error", () => {
+  writeUnclaimed();
+  const msg = 'Zenrows error 402: {"code":"AUTH006","title":"Concurrency limit reached (AUTH006)"}';
+  assert.equal(appendClaimHint(msg, { status: 402, body: msg }), msg);
+});
+
 test("appendClaimHint adds claim URL when unclaimed and quota/plan error", () => {
   writeUnclaimed("https://app.zenrows.com/claim/abc");
-  const msg = "Zenrows error 402: {\"code\":\"AUTH001\"}";
+  const msg = 'Zenrows error 402: {"code":"AUTH001"}';
   const out = appendClaimHint(msg, { status: 402, body: msg });
   assert.match(out, /Claim your Free account/);
   assert.match(out, /https:\/\/app\.zenrows\.com\/claim\/abc/);


### PR DESCRIPTION
Two changes. One adds a tool that was missing; the other fixes a comment that was wrong and cost us the nudge that mattered most.

## `account_usage`

Nothing on this server could answer "how many credits do I have left?". Responses carry `X-Request-Cost` and `X-Request-Credits` — what a call *cost*, after the fact — but there is no counterpart to `Concurrency-Limit` / `Concurrency-Remaining`. An agent could total its own spend and still not know the ceiling, so it found out by hitting a 402 telling it to buy a subscription.

`/v1/subscriptions/self/details` has always had the answer, and it does not count against concurrency — which is what makes it safe to call before a batch or straight after a failure.

**Called live against a real account while writing this**, it returns rather more than anything documents:

```json
{ "status": "ACTIVE", "period_ends_at": "2027-05-13T08:39:53Z",
  "usage": 5.66823039823616, "usage_credits": 62982, "credit_limit": 35999978,
  "usage_percent": 0,
  "plan": { "name": "Business", "price": 3239.89, "unit_cost": 8.9997e-05,
            "products": { "api": { "concurrency": { "limit": 100, "usage": 0 },
                                   "usage_credits": 59628 } } },
  "top_ups": [] }
```

The response is **passed through verbatim**, and that turned out to be load-bearing rather than lazy: `usage_credits` and `credit_limit` are the two most useful fields here, and neither appears in the `UsageDetails` interface the CLI declares. Reshaping to a known type would have dropped them.

Worth knowing for anyone touching this later: `plan.unit_cost` is **per plan**, not a platform constant. This account bills 8.9997e-05 per credit; Free bills 0.001. `credit_limit × unit_cost === plan.price` holds. Never convert between dollars and credits with a hardcoded factor.

## AUTH004 is not concurrency

`claim-hint.ts` read:

```js
/** AUTH004 is concurrency, not trial credits — don't nudge claim for it. */
const SKIP_CODES = new Set(["AUTH004"]);
```

AUTH004 is **"Usage Exceeded"** — the allowance itself is spent. The docs say so (`api-error-codes#AUTH004`) and production gateway records carry `err: "usage exceeded"`, `err_code: "AUTH004"` and `msg: "user allowance failure"` together. Concurrency is **AUTH006**, which the same page files under `429 Too Many Requests`.

So the nudge was suppressed at the one moment it is worth the most: an unclaimed Free agent that has just run through its allowance, and will otherwise walk away from the account and its usage history rather than claim it. Not a hypothetical population — 413 orgs are against this wall, one of them retrying at ~3.3 requests/second for a week with zero successes.

AUTH006 takes its place in the set, with a comment saying plainly that it is belt-and-braces: it arrives as 429, so it would never reach the 402 branch anyway.

The existing test asserted the old behaviour using a fabricated `"Concurrency limit reached (AUTH004)"` title. Flipped, with AUTH006 covered alongside it.

## Verification

- `typecheck`, `lint` and `prettier` clean on the touched files; **56 tests green**, 7 of them new.
- The tool was **run against the live endpoint**, not only a stub: all nine fields returned, `isError: false`.
- Five consecutive calls left `usage_credits` unchanged at 62,982, so "free to call" in the tool description is measured rather than assumed.
- The stubbed tests pin what a live call cannot: header auth (`X-API-Key` — the scraper's `apikey` query param does not work on this endpoint), no field renamed or dropped, a non-JSON body returned as `raw` rather than silently empty, failed statuses and network errors surfacing their cause, and a 402 here still reaching an unclaimed agent with the claim link.

Opened from a fork: I do not have push on this repo.

Context: ACT-1581, ACT-1577.