### PR TITLE
Name the scope the MCP token grants, instead of declaring none

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -36,6 +36,28 @@ function extractApiKey(req: Request): string | undefined {
 const AUTH_SERVER = process.env.OAUTH_AUTH_SERVER ?? "https://app.zenrows.com";
 const MCP_SERVER = process.env.MCP_SERVER ?? "https://mcp.zenrows.com";
 
+/**
+ * The scope this resource issues, named after what it actually grants.
+ *
+ * The access token IS the account's Zenrows API key: the authorization server hands
+ * the key back at /oauth/mcp/token, and every tool here calls the API with it. So an
+ * approved client can do anything the key can do, and one scope named `api` is the
+ * whole truth.
+ *
+ * It used to be declared as `[]`, which is worse than saying nothing: an empty list
+ * reads to a least-privilege client as "this resource has no scopes", when what we
+ * meant was "we never wrote them down".
+ *
+ * Splitting this — reading a page under one scope, spending credits on a
+ * 100,000-URL batch under another — is not an edit to this array. The token would
+ * have to carry the grant, and today it cannot: it is an opaque API key, minted by
+ * app.zenrows.com, and a raw key pasted straight into the Authorization header is a
+ * supported way to connect. Until the token can say what it was granted, this list
+ * must not claim more than one, because a scope we do not enforce is a lie told to
+ * exactly the clients careful enough to read it.
+ */
+const SCOPES_SUPPORTED = ["api"];
+
 app.get("/mcp/.well-known/oauth-authorization-server", (c) =>
   c.redirect("/.well-known/oauth-authorization-server", 301)
 );
@@ -47,7 +69,8 @@ app.get("/.well-known/oauth-protected-resource", (c) =>
     resource: MCP_SERVER,
     authorization_servers: [MCP_SERVER],
     bearer_methods_supported: ["header", "query"],
-    scopes_supported: [],
+    scopes_supported: SCOPES_SUPPORTED,
+    resource_documentation: "https://docs.zenrows.com",
   })
 );
 
@@ -64,6 +87,7 @@ app.get("/.well-known/oauth-authorization-server", (c) =>
     grant_types_supported: ["authorization_code"],
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: SCOPES_SUPPORTED,
   })
 );
 
@@ -169,7 +193,9 @@ app.all("/mcp", async (c) => {
       },
       401,
       {
-        "WWW-Authenticate": `Bearer realm="${AUTH_SERVER}", resource_metadata="${MCP_SERVER}/.well-known/oauth-protected-resource"`,
+        // RFC 6750: name the scope in the challenge too, so a client learns what it is
+        // being asked for without a second fetch of the metadata document.
+        "WWW-Authenticate": `Bearer realm="${AUTH_SERVER}", scope="${SCOPES_SUPPORTED.join(" ")}", resource_metadata="${MCP_SERVER}/.well-known/oauth-protected-resource"`,
         // CloudFront strips WWW-Authenticate — add Link header as RFC 8615 fallback
         // so MCP clients can still discover the OAuth server
         Link: `<${MCP_SERVER}/.well-known/oauth-protected-resource>; rel="oauth-protected-resource"`,

--- a/tests/well-known.test.ts
+++ b/tests/well-known.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+/**
+ * What this resource tells a client before the client trusts it with anything.
+ *
+ * These documents are the only machine-readable answer to "what am I granting?".
+ * `scopes_supported` shipped as `[]`, which a least-privilege client reads as "this
+ * resource has no scopes" rather than "nobody wrote them down", and the
+ * authorization-server document omitted the field entirely. Both now name the one
+ * scope the token really carries.
+ *
+ * Setting AWS_LAMBDA_FUNCTION_NAME before the import keeps src/http.ts from opening
+ * a listener: the module starts a dev server when it thinks it is not on Lambda.
+ */
+process.env.AWS_LAMBDA_FUNCTION_NAME = "test";
+
+const { handler } = await import("../src/http.ts");
+
+async function get(path: string) {
+  const response = await handler({
+    requestContext: { http: { method: "GET" } },
+    rawPath: path,
+    headers: {},
+  });
+
+  return { ...response, json: JSON.parse(response.body) as Record<string, unknown> };
+}
+
+test("the protected resource names the scope the token grants", async () => {
+  const { statusCode, json } = await get("/.well-known/oauth-protected-resource");
+
+  assert.equal(statusCode, 200);
+  assert.deepEqual(json.scopes_supported, ["api"]);
+  assert.equal(json.resource_documentation, "https://docs.zenrows.com");
+});
+
+test("an empty scope list is never published", async () => {
+  // The regression this file exists for: `[]` is a claim, and the wrong one.
+  for (const path of ["/.well-known/oauth-protected-resource", "/.well-known/oauth-authorization-server"]) {
+    const { json } = await get(path);
+    const scopes = json.scopes_supported as string[] | undefined;
+
+    assert.ok(Array.isArray(scopes), `${path} declares no scopes at all`);
+    assert.ok(scopes.length > 0, `${path} declares an empty scope list`);
+  }
+});
+
+test("the authorization server agrees with the resource", async () => {
+  const resource = await get("/.well-known/oauth-protected-resource");
+  const server = await get("/.well-known/oauth-authorization-server");
+
+  assert.deepEqual(server.json.scopes_supported, resource.json.scopes_supported);
+});
+
+test("the challenge on an unauthenticated call names the scope", async () => {
+  const response = await handler({
+    requestContext: { http: { method: "POST" } },
+    rawPath: "/mcp",
+    headers: {},
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+  });
+
+  assert.equal(response.statusCode, 401);
+
+  const challenge = response.headers["www-authenticate"];
+  assert.match(challenge, /scope="api"/);
+  assert.match(challenge, /resource_metadata="https:\/\/mcp\.zenrows\.com/);
+});


### PR DESCRIPTION
`mcp.zenrows.com/.well-known/oauth-protected-resource` publishes `scopes_supported: []`, and the authorization-server document omits the field. Both now name the one scope that is real.

## Why this and not two scopes

The access token **is** the account's Zenrows API key: `app.zenrows.com/oauth/mcp/token` returns the key, and every tool here calls the API with it. So an approved client can do anything that key can do, and `api` is the honest name for that.

Splitting it (reading a page vs. spending credits on a 100,000-URL batch) is **not** an edit to this array. The token would have to carry the grant, and it cannot today: it is an opaque key, and pasting a raw key into `Authorization` is a supported way to connect. The constant's docblock records that, so nobody later adds names to a list we do not enforce. A scope we do not check is a lie told to exactly the clients careful enough to read it.

## What changed

- `scopes_supported: ["api"]` on both well-known documents, from one constant.
- `scope="api"` in the `WWW-Authenticate` challenge (RFC 6750), so a client learns it without a second fetch.
- `resource_documentation` on the protected-resource document.

Nothing in the request path changes: no tool gains or loses a check, and no existing client has to re-authorise.

## Verification

`tests/well-known.test.ts` drives the real Lambda `handler`. Four tests, each run against the previous metadata first and failing there, including one that pins the actual regression: an empty scope array is never published again. 60 tests pass, `typecheck` and `lint` clean.

## Context

From the [is-agentic scan of zenrows.com](https://is-agentic.com/scan/zenrows.com). It is at 98/100 and "Scoped permissions" is the only Essential check left, sitting at 40% on this evidence: *"OAuth authorization server metadata at https://mcp.zenrows.com … no named OAuth scopes"*. That is this host, not app.zenrows.com, which is why [app#2016](https://github.com/ZenRows/app/pull/2016) alone would not have moved it.

Reaching production needs a `v*.*.*` tag, not just a merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)